### PR TITLE
Assign AQ War Effort related game objects to the AQ War Effort game event

### DIFF
--- a/World/Updates/Rel21/21000_12_aq_wareffort_game_event_gameobject.sql
+++ b/World/Updates/Rel21/21000_12_aq_wareffort_game_event_gameobject.sql
@@ -13,7 +13,7 @@ BEGIN
   SET @cOldRev = 'required_21000_11_STV_Sleeping_Creatures'; 
 
   -- Set the new revision string
-  SET @cNewRev = 'required_21000_12_aq_wareffort_game_event_gameobject';
+  SET @cNewRev = 'required_21000_11_STV_Sleeping_Creatures';
 
   -- Set thisRevision to the column name of db_version in the currently selected database
   SET @cThisRev := ((SELECT column_name FROM information_schema.`COLUMNS` WHERE table_name='db_version' AND table_schema=(SELECT DATABASE() AS thisDB FROM DUAL) AND column_name LIKE 'required%'));

--- a/World/Updates/Rel21/21000_12_aq_wareffort_game_event_gameobject.sql
+++ b/World/Updates/Rel21/21000_12_aq_wareffort_game_event_gameobject.sql
@@ -1,0 +1,74 @@
+-- --------------------------------------------------------------------------------
+-- This is an attempt to create a full transactional update
+-- --------------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`; 
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+  SET @cOldRev = 'required_21000_11_STV_Sleeping_Creatures'; 
+
+  -- Set the new revision string
+  SET @cNewRev = 'required_21000_12_aq_wareffort_game_event_gameobject';
+
+  -- Set thisRevision to the column name of db_version in the currently selected database
+  SET @cThisRev := ((SELECT column_name FROM information_schema.`COLUMNS` WHERE table_name='db_version' AND table_schema=(SELECT DATABASE() AS thisDB FROM DUAL) AND column_name LIKE 'required%'));
+
+  -- Set friendly Version Text
+  SET @cThisVersion = 'MaNGOSZero Database Rev 21000_12';
+ 
+  -- Only Proceed if the old values match
+  IF @cThisRev = @cOldRev THEN
+    -- Make this all a single transaction
+    START TRANSACTION;
+
+    -- Apply the Version Change from Old Version to New Version
+    SET @query = CONCAT('ALTER TABLE db_version CHANGE COLUMN ',@cOldRev, ' ' ,@cNewRev,' bit;');
+    PREPARE stmt1 FROM @query;
+    EXECUTE stmt1;
+    DEALLOCATE PREPARE stmt1;
+    -- The Above block is required for making table changes
+    
+    INSERT IGNORE INTO `db_version` SET `Version` = @cThisVersion;
+
+    -- If this is purely an incremental update, include this line
+    SET @cNewRev = @cThisVersion;
+
+    -- -- -- -- Normal Update / Insert / Delete statements will go here  -- -- -- -- --
+    INSERT INTO `game_event_gameobject` (`guid`,`event`) VALUES
+    (29294, 22),
+    (29301, 22),
+    (29300, 22),
+    (29299, 22),
+    (632445, 22),
+    (632444, 22),
+    (632441, 22),
+    (632442, 22),
+    (632443, 22);
+    -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+    
+    -- If we get here ok, commit the changes
+    IF bRollback = TRUE THEN
+      ROLLBACK;
+      SELECT '* UPDATE FAILED *' AS 'Status',@cThisRev AS 'DB is on Version';
+    ELSE
+      COMMIT;
+      SELECT '* UPDATE COMPLETE *' AS 'Status',@cNewRev AS 'DB is now on Version';
+    END IF;
+  ELSE
+    SELECT '* UPDATE SKIPPED *' AS 'Status',@cOldRev AS 'Required Version',@cThisRev AS 'Found Version';
+  END IF;
+
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;


### PR DESCRIPTION
This removes the AQ War Effort related game objects from Ironforge and
Orgrimmar by default and will only be displayed if event 22 is started.