### PR TITLE
Instance Dire Maul Fixes

### DIFF
--- a/World/Updates/Rel21/Rel21_20_003_Dire_Maul_Fixes.sql
+++ b/World/Updates/Rel21/Rel21_20_003_Dire_Maul_Fixes.sql
@@ -1,0 +1,149 @@
+-- ----------------------------------------------------------------
+-- This is an attempt to create a full transactional MaNGOS update
+-- Now compatible with newer MySql Databases (v1.5)
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`; 
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+    -- Current Values (TODO - must be a better way to do this)
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+
+    -- Expected Values
+    SET @cOldVersion = '21'; 
+    SET @cOldStructure = '20'; 
+    SET @cOldContent = '002';
+
+    -- New Values
+    SET @cNewVersion = '21';
+    SET @cNewStructure = '20';
+    SET @cNewContent = '003';
+                            -- DESCRIPTION IS 30 Characters MAX    
+    SET @cNewDescription = 'Dire_Maul_Dixes';
+
+                        -- COMMENT is 150 Characters MAX
+    SET @cNewComment = 'Fix gob loot template and repeatable quest The Gordok Ogre Suit';
+
+    -- Evaluate all settings
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cOldResult := (SELECT `description` FROM `db_version` WHERE `version`=@cOldVersion AND `structure`=@cOldStructure AND `content`=@cOldContent);
+    SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+    IF (@cCurResult = @cOldResult) THEN    -- Does the current version match the expected version
+        -- APPLY UPDATE
+        START TRANSACTION;
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL BELOW -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+		
+		/*
+			Fix Loot template for "Knot Thimblejack's Cache"
+			See : https://classic.wowhead.com/object=179501/knot-thimblejacks-cache#contains
+			for loot composition
+			Epic and blue loot have been put in separate groups
+		*/
+		/* Delete existing DATA  */
+		DELETE FROM `gameobject_loot_template` WHERE `entry` IN (16591);
+		INSERT INTO `gameobject_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) 
+		VALUES 	
+			('16591', '8171', '47', '0', '1', '10', '0'),
+			('16591', '8170', '44', '0', '5', '20', '0'),
+			('16591', '14047', '42', '1', '5', '20', '0'),
+			('16591', '18240', '36', '1', '-18240', '2', '0'), /* Ogre Tanin */
+			('16591', '8154', '33', '1', '1', '12', '0'),
+			('16591', '8165', '33', '1', '1', '12', '0'),
+			('16591', '15408', '33', '2', '1', '8', '0'),
+			('16591', '8150', '27', '2', '2', '11', '0'),
+			('16591', '15412', '27', '2', '2', '7', '0'),
+			('16591', '4338', '18', '3', '10', '15', '0'),
+			('16591', '4304', '18', '3', '5', '20', '0'),
+			('16591', '8153', '18', '3', '1', '9', '0'),
+			('16591', '14256', '18', '3', '2', '8', '0'),
+			-- Blue items
+			('16591', '18515', '14', '4', '1', '1', '0'),
+			('16591', '18416', '13', '4', '1', '1', '0'),
+			('16591', '18516', '13', '4', '1', '1', '0'),
+			('16591', '18418', '12', '4', '1', '1', '0'),
+			('16591', '18415', '12', '4', '1', '1', '0'),
+			('16591', '18514', '11', '4', '1', '1', '0'),
+			('16591', '18417', '10', '4', '1', '1', '0'),
+
+			-- some white items 
+			('16591', '15414', '10', '5', '2', '7', '0'),
+			('16591', '15416', '9', '5', '2', '6', '0'),
+			-- Epic items
+			('16591', '18414', '1.9', '6', '1', '1', '0'),
+			('16591', '18519', '1.8', '6', '1', '1', '0'),
+			('16591', '18517', '1.5', '6', '1', '1', '0'),
+			('16591', '18518', '1.5', '6', '1', '1', '0')
+
+			;
+		
+		/*
+			Fix repeatable quest 5519 "The Gordok Ogre Suit", that must not be displayed before 5518 is complete !
+		*/
+		UPDATE `quest_template` SET `PrevQuestId` = '5518' WHERE (`entry` = '5519');
+
+		
+
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL ABOVE -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+        -- If we get here ok, commit the changes
+        IF bRollback = TRUE THEN
+            ROLLBACK;
+            SHOW ERRORS;
+            SELECT '* UPDATE FAILED *' AS `===== Status =====`,@cCurResult AS `===== DB is on Version: =====`;
+        ELSE
+            COMMIT;
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            -- UPDATE THE DB VERSION
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure, @cNewContent, @cNewDescription, @cNewComment);
+            SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+            SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,@cNewResult AS `===== DB is now on Version =====`;
+        END IF;
+    ELSE    -- Current version is not the expected version
+        IF (@cCurResult = @cNewResult) THEN    -- Does the current version match the new version
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cCurResult AS `===== DB is already on Version =====`;
+        ELSE    -- Current version is not one related to this update
+            IF(@cCurResult IS NULL) THEN    -- Something has gone wrong
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                IF(@cOldResult IS NULL) THEN    -- Something has gone wrong
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SET @cOldResult = CONCAT('Rel',@cOldVersion, '_', @cOldStructure, '_', @cOldContent, ' - ','IS NOT APPLIED');
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cOldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                ELSE
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cOldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+


### PR DESCRIPTION
- Fix Loot template for "Knot Thimblejack's Cache"
			See : https://classic.wowhead.com/object=179501/knot-thimblejacks-cache#contains
			for loot composition
- Fix repeatable quest 5519 "The Gordok Ogre Suit", that must not be displayed before 5518 is complete !