### PR TITLE
2x Ironforge spelling fix for gossip_menu_option

### DIFF
--- a/World/Updates/Rel22/Rel22_01_014_Ironforge_spelling_fix_gossip_menu_option.sql
+++ b/World/Updates/Rel22/Rel22_01_014_Ironforge_spelling_fix_gossip_menu_option.sql
@@ -45,7 +45,7 @@ BEGIN
 
 	-- Update Speeling fix.
 	UPDATE `gossip_menu_option` SET `option_text`='Ahh ... Ironforge.' WHERE `menu_id`=2051 AND `id`=0;
-	UPDATE `gossip_menu_option` SET `option_text`='Ahh ... Ironforge.' WHERE `menu_id`=2058 AND `id`=0;
+	UPDATE `gossip_menu_option` SET `option_text`='Ironforge?' WHERE `menu_id`=2058 AND `id`=0;
 	-- locales_ Tables are generally not updated this way, as they load empty on default.
 	-- UPDATE `locales_gossip_menu_option` SET `option_text_loc3`='Ahh ... Ironforge.' WHERE `menu_id`=2051 AND `id`=0;
 	-- UPDATE `locales_gossip_menu_option` SET `option_text_loc3`='Ironforge.' WHERE `menu_id`=2058 AND `id`=0;

--- a/World/Updates/Rel22/Rel22_01_014_Ironforge_spelling_fix_gossip_menu_option.sql
+++ b/World/Updates/Rel22/Rel22_01_014_Ironforge_spelling_fix_gossip_menu_option.sql
@@ -1,0 +1,105 @@
+-- ----------------------------------------------------------------
+-- This is an attempt to create a full transactional MaNGOS update
+-- Now compatible with newer MySql Databases (v1.5)
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`; 
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+    -- Current Values (TODO - must be a better way to do this)
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+
+    -- Expected Values
+    SET @cOldVersion = '22'; 
+    SET @cOldStructure = '01'; 
+    SET @cOldContent = '013';
+
+    -- New Values
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '01';
+    SET @cNewContent = '014';
+                            -- DESCRIPTION IS 30 Characters MAX    
+    SET @cNewDescription = 'Ironforge spelling fix';
+
+                        -- COMMENT is 150 Characters MAX
+    SET @cNewComment = 'Ironforge spelling fix in gossip_menu_option';
+
+    -- Evaluate all settings
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cOldResult := (SELECT `description` FROM `db_version` WHERE `version`=@cOldVersion AND `structure`=@cOldStructure AND `content`=@cOldContent);
+    SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+    IF (@cCurResult = @cOldResult) THEN    -- Does the current version match the expected version
+        -- APPLY UPDATE
+        START TRANSACTION;
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL BELOW -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+		-- Update Speeling fix.
+	UPDATE `gossip_menu_option` SET `option_text_loc3`='Ahh ... Ironforge.' WHERE `menu_id`=2051 AND `id`=0;
+	UPDATE `gossip_menu_option` SET `option_text_loc3`='Ahh ... Ironforge.' WHERE `menu_id`=2058 AND `id`=0;
+	UPDATE `locales_gossip_menu_option` SET `option_text_loc3`='Ahh ... Ironforge.' WHERE `menu_id`=2051 AND `id`=0;
+	UPDATE `locales_gossip_menu_option` SET `option_text_loc3`='Ironforge.' WHERE `menu_id`=2058 AND `id`=0;
+
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL ABOVE -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+        -- If we get here ok, commit the changes
+        IF bRollback = TRUE THEN
+            ROLLBACK;
+            SHOW ERRORS;
+            SELECT '* UPDATE FAILED *' AS `===== Status =====`,@cCurResult AS `===== DB is on Version: =====`;
+        ELSE
+            COMMIT;
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            -- UPDATE THE DB VERSION
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure, @cNewContent, @cNewDescription, @cNewComment);
+            SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+            SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,@cNewResult AS `===== DB is now on Version =====`;
+        END IF;
+    ELSE    -- Current version is not the expected version
+        IF (@cCurResult = @cNewResult) THEN    -- Does the current version match the new version
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cCurResult AS `===== DB is already on Version =====`;
+        ELSE    -- Current version is not one related to this update
+            IF(@cCurResult IS NULL) THEN    -- Something has gone wrong
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                IF(@cOldResult IS NULL) THEN    -- Something has gone wrong
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SET @cOldResult = CONCAT('Rel',@cOldVersion, '_', @cOldStructure, '_', @cOldContent, ' - ','IS NOT APPLIED');
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cOldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                ELSE
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cOldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+

--- a/World/Updates/Rel22/Rel22_01_014_Ironforge_spelling_fix_gossip_menu_option.sql
+++ b/World/Updates/Rel22/Rel22_01_014_Ironforge_spelling_fix_gossip_menu_option.sql
@@ -19,12 +19,12 @@ BEGIN
     -- Expected Values
     SET @cOldVersion = '22'; 
     SET @cOldStructure = '01'; 
-    SET @cOldContent = '013';
+    SET @cOldContent = '014';
 
     -- New Values
     SET @cNewVersion = '22';
     SET @cNewStructure = '01';
-    SET @cNewContent = '014';
+    SET @cNewContent = '015';
                             -- DESCRIPTION IS 30 Characters MAX    
     SET @cNewDescription = 'Ironforge spelling fix';
 
@@ -43,11 +43,12 @@ BEGIN
         -- -- PLACE UPDATE SQL BELOW -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
         -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
 
-		-- Update Speeling fix.
-	UPDATE `gossip_menu_option` SET `option_text_loc3`='Ahh ... Ironforge.' WHERE `menu_id`=2051 AND `id`=0;
-	UPDATE `gossip_menu_option` SET `option_text_loc3`='Ahh ... Ironforge.' WHERE `menu_id`=2058 AND `id`=0;
-	UPDATE `locales_gossip_menu_option` SET `option_text_loc3`='Ahh ... Ironforge.' WHERE `menu_id`=2051 AND `id`=0;
-	UPDATE `locales_gossip_menu_option` SET `option_text_loc3`='Ironforge.' WHERE `menu_id`=2058 AND `id`=0;
+	-- Update Speeling fix.
+	UPDATE `gossip_menu_option` SET `option_text`='Ahh ... Ironforge.' WHERE `menu_id`=2051 AND `id`=0;
+	UPDATE `gossip_menu_option` SET `option_text`='Ahh ... Ironforge.' WHERE `menu_id`=2058 AND `id`=0;
+	-- locales_ Tables are generally not updated this way, as they load empty on default.
+	-- UPDATE `locales_gossip_menu_option` SET `option_text_loc3`='Ahh ... Ironforge.' WHERE `menu_id`=2051 AND `id`=0;
+	-- UPDATE `locales_gossip_menu_option` SET `option_text_loc3`='Ironforge.' WHERE `menu_id`=2058 AND `id`=0;
 
         -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
         -- -- PLACE UPDATE SQL ABOVE -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --


### PR DESCRIPTION
Fixing two spelling errors in gossip_menu_option for "menu_id=2051 AND id=0" and "menu_id=2058 AND id=0"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/database/120)
<!-- Reviewable:end -->
