### PR TITLE
Adds missing server parameter for mariadb commands

### DIFF
--- a/InstallDatabases.sh
+++ b/InstallDatabases.sh
@@ -104,7 +104,7 @@ mysqlconfigeditor()
 determineDBCommand()
 {
 	if [ $dbname = "MariaDB" ]; then
-		dbcommand="mariadb -u ${user} -p${pass} -q -s"
+		dbcommand="mariadb -h ${svr} -u ${user} -p${pass} -q -s"
 	elif [ $dbname = "MySQL" ]; then
 		dbcommand="mysql --login-path=local -q -s"
 	else


### PR DESCRIPTION
Running InstallDatabases.sh ignores the server parameter and is assumed to run on a local database. This adds the parameter for MariaDB database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/database/131)
<!-- Reviewable:end -->
