### PR TITLE
Add scheduled exit mangos strings

### DIFF
--- a/World/Updates/Rel22/Rel22_04_035_Scheduled_Exit_Mangos_Strings.sql
+++ b/World/Updates/Rel22/Rel22_04_035_Scheduled_Exit_Mangos_Strings.sql
@@ -1,0 +1,107 @@
+-- ----------------------------------------------------------------
+-- This is an attempt to create a full transactional MaNGOS update
+-- Now compatible with newer MySql Databases (v1.5)
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+    -- Current Values (TODO - must be a better way to do this)
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+
+    -- Expected Values
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '04';
+    SET @cOldContent = '034';
+
+    -- New Values
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '04';
+    SET @cNewContent = '035';
+                            -- DESCRIPTION IS 30 Characters MAX
+    SET @cNewDescription = 'Scheduled_Exit_Strings';
+
+                        -- COMMENT is 150 Characters MAX
+    SET @cNewComment = 'Add localized mangos_string entries for ScheduledExit warning messages.';
+
+    -- Evaluate all settings
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cOldResult := (SELECT `description` FROM `db_version` WHERE `version`=@cOldVersion AND `structure`=@cOldStructure AND `content`=@cOldContent);
+    SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+    IF (@cCurResult = @cOldResult) THEN    -- Does the current version match the expected version
+        -- APPLY UPDATE
+        START TRANSACTION;
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL BELOW -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+INSERT INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `source_file`, `source_enum_wrapper`, `source_enum_tag`) VALUES
+(1717,'This realm will be automatically restarting in 15 Minutes as part of its weekly schedule. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_15_MIN'),
+(1718,'This realm will be automatically restarting in 10 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_10_MIN'),
+(1719,'This realm will be automatically restarting in 5 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_5_MIN'),
+(1720,'This realm will be automatically restarting in 1 Minute as part of its weekly schedule. Please ensure you are in a safe area. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_1_MIN'),
+(1721,'This realm will be automatically shutting down in 15 Minutes as part of its weekly schedule. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_15_MIN'),
+(1722,'This realm will be automatically shutting down in 10 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_10_MIN'),
+(1723,'This realm will be automatically shutting down in 5 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_5_MIN'),
+(1724,'This realm will be automatically shutting down in 1 Minute as part of its weekly schedule. Please ensure you are in a safe area. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_1_MIN');
+
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL ABOVE -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+        -- If we get here ok, commit the changes
+        IF bRollback = TRUE THEN
+            ROLLBACK;
+            SHOW ERRORS;
+            SELECT '* UPDATE FAILED *' AS `===== Status =====`,@cCurResult AS `===== DB is on Version: =====`;
+        ELSE
+            COMMIT;
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            -- UPDATE THE DB VERSION
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure, @cNewContent, @cNewDescription, @cNewComment);
+            SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+            SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,@cNewResult AS `===== DB is now on Version =====`;
+        END IF;
+    ELSE    -- Current version is not the expected version
+        IF (@cCurResult = @cNewResult) THEN    -- Does the current version match the new version
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cCurResult AS `===== DB is already on Version =====`;
+        ELSE    -- Current version is not one related to this update
+            IF(@cCurResult IS NULL) THEN    -- Something has gone wrong
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                IF(@cOldResult IS NULL) THEN    -- Something has gone wrong
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SET @cOldResult = CONCAT('Rel',@cOldVersion, '_', @cOldStructure, '_', @cOldContent, ' - ','IS NOT APPLIED');
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cOldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                ELSE
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cOldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;

--- a/World/Updates/Rel22/Rel22_04_035_Scheduled_Exit_Mangos_Strings.sql
+++ b/World/Updates/Rel22/Rel22_04_035_Scheduled_Exit_Mangos_Strings.sql
@@ -44,14 +44,14 @@ BEGIN
         -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
 
 INSERT INTO `mangos_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `source_file`, `source_enum_wrapper`, `source_enum_tag`) VALUES
-(1717,'This realm will be automatically restarting in 15 Minutes as part of its weekly schedule. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_15_MIN'),
-(1718,'This realm will be automatically restarting in 10 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_10_MIN'),
-(1719,'This realm will be automatically restarting in 5 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_5_MIN'),
-(1720,'This realm will be automatically restarting in 1 Minute as part of its weekly schedule. Please ensure you are in a safe area. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_1_MIN'),
-(1721,'This realm will be automatically shutting down in 15 Minutes as part of its weekly schedule. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_15_MIN'),
-(1722,'This realm will be automatically shutting down in 10 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_10_MIN'),
-(1723,'This realm will be automatically shutting down in 5 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_5_MIN'),
-(1724,'This realm will be automatically shutting down in 1 Minute as part of its weekly schedule. Please ensure you are in a safe area. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_1_MIN');
+(1730,'This realm will be automatically restarting in 15 Minutes as part of its weekly schedule. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_15_MIN'),
+(1731,'This realm will be automatically restarting in 10 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_10_MIN'),
+(1732,'This realm will be automatically restarting in 5 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_5_MIN'),
+(1733,'This realm will be automatically restarting in 1 Minute as part of its weekly schedule. Please ensure you are in a safe area. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_RESTART_1_MIN'),
+(1734,'This realm will be automatically shutting down in 15 Minutes as part of its weekly schedule. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_15_MIN'),
+(1735,'This realm will be automatically shutting down in 10 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_10_MIN'),
+(1736,'This realm will be automatically shutting down in 5 Minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_5_MIN'),
+(1737,'This realm will be automatically shutting down in 1 Minute as part of its weekly schedule. Please ensure you are in a safe area. Downtime is expected to be 1-2 minutes.',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'Language.h','MangosStrings','LANG_SCHEDULED_EXIT_SHUTDOWN_1_MIN');
 
         -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
         -- -- PLACE UPDATE SQL ABOVE -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --


### PR DESCRIPTION
Add scheduled exit warning strings to mangos_strings

Adds database-backed string entries for the new scheduled exit / scheduled maintenance warning messages.

Purpose:

* Moves scheduled restart warning text out of `mangosd.conf`.
* Stores the default warning text in `mangos_strings`.
* Allows the messages to be localised through the existing database string system.
* Keeps `mangosd.conf` focused on scheduling options rather than player-facing text content.

Added strings:

* 15-minute scheduled restart warning.
* 10-minute scheduled restart warning.
* 5-minute scheduled restart warning.
* 1-minute scheduled restart warning.

Default wording is based on the legacy weekly restart messages previously sent through external Remote Admin/TST scripts, with corrected grammar where appropriate.

Related source behavior:

* `mangosd` now looks up the configured scheduled-exit warning text from `mangos_strings`.
* The warning messages are sent through `SERVER_MSG_CUSTOM` / `SMSG_SERVER_MESSAGE`, so they appear in the same server-message channel as the built-in shutdown/restart countdowns.
* The scheduled exit feature remains disabled by default.

Related PRs:

* Paired with the mangosd scheduled-exit source PR.
* Paired with the realmd scheduled-exit source PR.
* The source PRs also update the relevant config version numbers in `MangosParams.cmake`.

Validation:

* Database update applied locally.
* `mangosd` scheduled restart flow tested with the full 15/10/5/1 minute cadence.
* Source-side scheduled-exit tests passed in the paired source PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/database/144)
<!-- Reviewable:end -->
