### PR TITLE
AH subprocess Phase 2 (DB): custody_ledger table + `ah repair` command + custody differential

### DIFF
--- a/Character/Updates/Rel22/Rel22_05_001_Add_Custody_Ledger_Table.sql
+++ b/Character/Updates/Rel22/Rel22_05_001_Add_Custody_Ledger_Table.sql
@@ -1,0 +1,117 @@
+-- ----------------------------------------------------------------
+-- This is an attempt to create a full transactional MaNGOS update
+-- Now compatible with newer MySql Databases (v1.5)
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+    -- Current Values (TODO - must be a better way to do this)
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+
+    -- Expected Values
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '04';
+    SET @cOldContent = '001';
+
+    -- New Values
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '05';
+    SET @cNewContent = '001';
+                            -- DESCRIPTION IS 30 Characters MAX
+    SET @cNewDescription = 'Add_Custody_Ledger_Table';
+
+                        -- COMMENT is 150 Characters MAX
+    SET @cNewComment = 'Phase2 AH custody escrow ledger';
+
+    -- Evaluate all settings
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @oldResult := (SELECT `description` FROM `db_version` WHERE `version`=@cOldVersion AND `structure`=@cOldStructure AND `content`=@cOldContent);
+    SET @newResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+    IF (@cCurResult = @oldResult) THEN    -- Does the current version match the expected version
+        -- APPLY UPDATE
+        START TRANSACTION;
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL BELOW -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+    DROP TABLE IF EXISTS `custody_ledger`;
+    CREATE TABLE `custody_ledger` (
+        `id`               INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+        `idem_key`         VARCHAR(64)      NOT NULL,
+        `kind`             TINYINT(3) UNSIGNED NOT NULL,
+        `role`             TINYINT(3) UNSIGNED NOT NULL,
+        `state`            TINYINT(3) UNSIGNED NOT NULL DEFAULT '0',
+        `owner_guid`       INT(10) UNSIGNED NOT NULL DEFAULT '0',
+        `beneficiary_guid` INT(10) UNSIGNED NOT NULL DEFAULT '0',
+        `amount`           INT(10) UNSIGNED NOT NULL DEFAULT '0',
+        `item_guid`        INT(10) UNSIGNED NOT NULL DEFAULT '0',
+        `auction_id`       INT(10) UNSIGNED NOT NULL DEFAULT '0',
+        `created_time`     BIGINT(20) NOT NULL DEFAULT '0',
+        `resolved_time`    BIGINT(20) NOT NULL DEFAULT '0',
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `uk_idem` (`idem_key`),
+        KEY `idx_auction` (`auction_id`),
+        KEY `idx_state` (`state`)
+    ) ENGINE=InnoDB;
+
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL ABOVE -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+        -- If we get here ok, commit the changes
+        IF bRollback = TRUE THEN
+            ROLLBACK;
+            SHOW ERRORS;
+            SELECT '* UPDATE FAILED *' AS `===== Status =====`,@cCurResult AS `===== DB is on Version: =====`;
+        ELSE
+            COMMIT;
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            -- UPDATE THE DB VERSION
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure, @cNewContent, @cNewDescription, @cNewComment);
+            SET @newResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+            SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,@newResult AS `===== DB is now on Version =====`;
+        END IF;
+    ELSE    -- Current version is not the expected version
+        IF (@cCurResult = @newResult) THEN    -- Does the current version match the new version
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cCurResult AS `===== DB is already on Version =====`;
+        ELSE    -- Current version is not one related to this update
+            IF(@cCurResult IS NULL) THEN    -- Something has gone wrong
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                IF(@oldResult IS NULL) THEN    -- Something has gone wrong
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SET @oldResult = CONCAT('Rel',@cOldVersion, '_', @cOldStructure, '_', @cOldContent, ' - ','IS NOT APPLIED');
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@oldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                ELSE
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@oldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;

--- a/Tools/custody_diff.sql
+++ b/Tools/custody_diff.sql
@@ -1,3 +1,35 @@
+-- =============================================================================
+-- Tools/custody_diff.sql  --  AH custody acceptance differential (DEV/QA TOOL)
+-- =============================================================================
+--
+-- WHAT THIS IS
+--   A read-only developer/QA diagnostic for the mangoszero SERVER's Auction
+--   House "custody" feature -- the in-mangosd custody / escrow-ledger that routes
+--   the player AH write seams (create / bid / buyout / win / cancel / expire)
+--   through one checked, crash-safe transaction, gated behind the default-OFF
+--   `AH.Service.Custody` config. It changes NO schema and is NOT a migration:
+--   the DB updater never applies it. It lives in Tools/ beside the other
+--   hand-run diagnostics (mangos_spell_check.sql, etc.).
+--
+-- WHY IT EXISTS
+--   Custody moves real gold / items / mail bookkeeping onto a new code path, so
+--   its acceptance bar is that it stays BYTE-IDENTICAL to the legacy path in
+--   everything a player can observe. This script is that proof: it diffs the
+--   player-visible projection -- `characters.money`, `mail`, `mail_items`,
+--   `item_instance`, `auction` -- between a custody-OFF run and a custody-ON run.
+--   Any non-empty *_DIFF section is a custody regression that must be fixed
+--   before the feature is trusted.
+--
+-- WHEN TO RUN IT
+--   During the custody PROMOTION process (server repo: the custody promotion
+--   runbook), BEFORE flipping `AH.Service.Custody` default-on -- and again after
+--   any change to the custody seams. It is run BY HAND against two DISPOSABLE,
+--   quiesced Character-DB CLONES (NEVER a live/production realm DB): replay one
+--   identical seeded AH workload on a clone with custody off and a clone with
+--   custody on, then source this script; every *_DIFF section must return zero
+--   rows.
+--
+-- -----------------------------------------------------------------------------
 -- MaNGOS Zero AH custody player-visible differential.
 --
 -- Preconditions:

--- a/Tools/custody_diff.sql
+++ b/Tools/custody_diff.sql
@@ -1,0 +1,360 @@
+-- MaNGOS Zero AH custody player-visible differential.
+--
+-- Preconditions:
+--   * Run one identical, seeded workload on two quiesced Character DB clones:
+--       A: AH.Service.Custody = 0
+--       B: AH.Service.Custody = 1
+--   * Use named test characters, items, and auction ids; keep AH bot off.
+--   * Start both clones from the same idle MAX(mail.id) and MAX(auction.id)
+--     snapshot. This script compares mail_items.mail_id and auction.id
+--     directly, as required by the player-visible projection.
+--   * Allow no other logins or background auction/mail activity while replaying.
+--   * Prefer a pinned/normalized clock. If wall-clock timestamps differ between
+--     clone runs, keep @compare_absolute_mail_times = 0 and
+--     @compare_absolute_auction_times = 0 so the mail deliver/expire times and
+--     the auction.time (expiry) column are dumped for inspection but excluded
+--     from the diff. Custody never alters these columns; only clock drift does.
+--   * custody_ledger is intentionally excluded: only player-visible tables are
+--     compared here.
+--
+-- The Character DB schema has no persisted "sent" or "created_time" column.
+-- SendMailToInTransaction computes deliver_time as time(NULL) + deliver_delay,
+-- and custody AH mail uses deliver_delay = 0. This script reports the stored
+-- deliver/expire windows and can either compare absolute mail times or normalize
+-- them out; proving "deliver_time - sent == 0" requires the workload harness or
+-- source review because "sent" is not stored.
+--
+-- Usage:
+--   1. Edit the schema names below, or set @clone_a/@clone_b before sourcing.
+--   2. mysql --table -u <user> -p < Tools/custody_diff.sql   (run from the mangoszero/database repo root)
+--   3. Every *_DIFF section must return zero rows.
+
+SET @clone_a := COALESCE(@clone_a, 'character0_custody_off');
+SET @clone_b := COALESCE(@clone_b, 'character0_custody_on');
+SET @compare_absolute_mail_times := COALESCE(@compare_absolute_mail_times, 0);
+SET @compare_absolute_auction_times := COALESCE(@compare_absolute_auction_times, 0);
+
+SET @a := CONCAT('`', REPLACE(@clone_a, '`', '``'), '`');
+SET @b := CONCAT('`', REPLACE(@clone_b, '`', '``'), '`');
+
+SELECT 'custody_diff inputs' AS section,
+       @clone_a AS clone_a_custody_off,
+       @clone_b AS clone_b_custody_on,
+       @compare_absolute_mail_times AS compare_absolute_mail_times;
+
+SELECT 'RAW_A_CHARACTERS: SELECT guid, money FROM characters ORDER BY guid' AS section;
+SET @sql := CONCAT('SELECT guid, money FROM ', @a, '.`characters` ORDER BY guid');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'RAW_B_CHARACTERS: SELECT guid, money FROM characters ORDER BY guid' AS section;
+SET @sql := CONCAT('SELECT guid, money FROM ', @b, '.`characters` ORDER BY guid');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'RAW_A_MAIL: full spec columns incl sender/messageType/stationery/cod/expire_time' AS section;
+SET @sql := CONCAT(
+    'SELECT receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked, deliver_time, expire_time ',
+    'FROM ', @a, '.`mail` ORDER BY receiver, deliver_time, money, subject');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'RAW_B_MAIL: full spec columns incl sender/messageType/stationery/cod/expire_time' AS section;
+SET @sql := CONCAT(
+    'SELECT receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked, deliver_time, expire_time ',
+    'FROM ', @b, '.`mail` ORDER BY receiver, deliver_time, money, subject');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'RAW_A_MAIL_ITEMS: SELECT mail_id, item_guid, item_template, receiver FROM mail_items ORDER BY receiver, item_guid' AS section;
+SET @sql := CONCAT('SELECT mail_id, item_guid, item_template, receiver FROM ', @a, '.`mail_items` ORDER BY receiver, item_guid');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'RAW_B_MAIL_ITEMS: SELECT mail_id, item_guid, item_template, receiver FROM mail_items ORDER BY receiver, item_guid' AS section;
+SET @sql := CONCAT('SELECT mail_id, item_guid, item_template, receiver FROM ', @b, '.`mail_items` ORDER BY receiver, item_guid');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'RAW_A_ITEM_INSTANCE: SELECT guid, owner_guid FROM item_instance ORDER BY guid' AS section;
+SET @sql := CONCAT('SELECT guid, owner_guid FROM ', @a, '.`item_instance` ORDER BY guid');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'RAW_B_ITEM_INSTANCE: SELECT guid, owner_guid FROM item_instance ORDER BY guid' AS section;
+SET @sql := CONCAT('SELECT guid, owner_guid FROM ', @b, '.`item_instance` ORDER BY guid');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'RAW_A_AUCTION: SELECT * FROM auction ORDER BY id' AS section;
+SET @sql := CONCAT('SELECT * FROM ', @a, '.`auction` ORDER BY id');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'RAW_B_AUCTION: SELECT * FROM auction ORDER BY id' AS section;
+SET @sql := CONCAT('SELECT * FROM ', @b, '.`auction` ORDER BY id');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+DROP TEMPORARY TABLE IF EXISTS custody_diff_characters_a;
+DROP TEMPORARY TABLE IF EXISTS custody_diff_characters_b;
+DROP TEMPORARY TABLE IF EXISTS custody_diff_mail_a;
+DROP TEMPORARY TABLE IF EXISTS custody_diff_mail_b;
+DROP TEMPORARY TABLE IF EXISTS custody_diff_mail_items_a;
+DROP TEMPORARY TABLE IF EXISTS custody_diff_mail_items_b;
+DROP TEMPORARY TABLE IF EXISTS custody_diff_item_instance_a;
+DROP TEMPORARY TABLE IF EXISTS custody_diff_item_instance_b;
+DROP TEMPORARY TABLE IF EXISTS custody_diff_auction_a;
+DROP TEMPORARY TABLE IF EXISTS custody_diff_auction_b;
+
+SET @sql := CONCAT('CREATE TEMPORARY TABLE custody_diff_characters_a AS ',
+                   'SELECT guid, money FROM ', @a, '.`characters`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+SET @sql := CONCAT('CREATE TEMPORARY TABLE custody_diff_characters_b AS ',
+                   'SELECT guid, money FROM ', @b, '.`characters`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @mail_time_cols := IF(@compare_absolute_mail_times = 1,
+                          'deliver_time, expire_time, CAST(NULL AS SIGNED) AS expire_delay',
+                          'CAST(NULL AS UNSIGNED) AS deliver_time, CAST(NULL AS UNSIGNED) AS expire_time, CAST(expire_time AS SIGNED) - CAST(deliver_time AS SIGNED) AS expire_delay');
+SET @sql := CONCAT('CREATE TEMPORARY TABLE custody_diff_mail_a AS ',
+                   'SELECT receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked, ',
+                   @mail_time_cols, ' FROM ', @a, '.`mail`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+SET @sql := CONCAT('CREATE TEMPORARY TABLE custody_diff_mail_b AS ',
+                   'SELECT receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked, ',
+                   @mail_time_cols, ' FROM ', @b, '.`mail`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql := CONCAT('CREATE TEMPORARY TABLE custody_diff_mail_items_a AS ',
+                   'SELECT mail_id, item_guid, item_template, receiver FROM ', @a, '.`mail_items`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+SET @sql := CONCAT('CREATE TEMPORARY TABLE custody_diff_mail_items_b AS ',
+                   'SELECT mail_id, item_guid, item_template, receiver FROM ', @b, '.`mail_items`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql := CONCAT('CREATE TEMPORARY TABLE custody_diff_item_instance_a AS ',
+                   'SELECT guid, owner_guid FROM ', @a, '.`item_instance`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+SET @sql := CONCAT('CREATE TEMPORARY TABLE custody_diff_item_instance_b AS ',
+                   'SELECT guid, owner_guid FROM ', @b, '.`item_instance`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- auction.time is expireTime = time(NULL) + etime, a wall-clock timestamp set at
+-- creation (identical between custody on/off; only clock drift between clone runs
+-- differs). Normalize it out by default exactly like the mail times, so an
+-- unpinned-clock run does not false-positive every created auction. AUCTION_DIFF
+-- joins this column with <=> so NULL matches NULL when normalized.
+SET @auction_time_col := IF(@compare_absolute_auction_times = 1, 'time', 'CAST(NULL AS UNSIGNED) AS time');
+SET @auction_cols := CONCAT('id, houseid, itemguid, item_template, item_count, item_randompropertyid, ',
+                            'itemowner, buyoutprice, ', @auction_time_col, ', buyguid, lastbid, startbid, deposit');
+SET @sql := CONCAT('CREATE TEMPORARY TABLE custody_diff_auction_a AS SELECT ', @auction_cols, ' FROM ', @a, '.`auction`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+SET @sql := CONCAT('CREATE TEMPORARY TABLE custody_diff_auction_b AS SELECT ', @auction_cols, ' FROM ', @b, '.`auction`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'MAIL_TIME_WINDOW_A: inspect when absolute mail times are normalized out' AS section;
+SET @sql := CONCAT('SELECT COUNT(*) AS rows_seen, MIN(deliver_time) AS min_deliver_time, MAX(deliver_time) AS max_deliver_time, ',
+                   'MIN(CAST(expire_time AS SIGNED) - CAST(deliver_time AS SIGNED)) AS min_expire_delay, ',
+                   'MAX(CAST(expire_time AS SIGNED) - CAST(deliver_time AS SIGNED)) AS max_expire_delay ',
+                   'FROM ', @a, '.`mail`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'MAIL_TIME_WINDOW_B: inspect when absolute mail times are normalized out' AS section;
+SET @sql := CONCAT('SELECT COUNT(*) AS rows_seen, MIN(deliver_time) AS min_deliver_time, MAX(deliver_time) AS max_deliver_time, ',
+                   'MIN(CAST(expire_time AS SIGNED) - CAST(deliver_time AS SIGNED)) AS min_expire_delay, ',
+                   'MAX(CAST(expire_time AS SIGNED) - CAST(deliver_time AS SIGNED)) AS max_expire_delay ',
+                   'FROM ', @b, '.`mail`');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SELECT 'CHARACTERS_DIFF: zero rows means pass' AS section;
+SELECT 'A_MINUS_B' AS diff_side, a.guid, a.money
+FROM custody_diff_characters_a a
+LEFT JOIN custody_diff_characters_b b
+  ON b.guid = a.guid AND b.money = a.money
+WHERE b.guid IS NULL
+UNION ALL
+SELECT 'B_MINUS_A' AS diff_side, b.guid, b.money
+FROM custody_diff_characters_b b
+LEFT JOIN custody_diff_characters_a a
+  ON a.guid = b.guid AND a.money = b.money
+WHERE a.guid IS NULL
+ORDER BY guid, diff_side;
+
+SELECT 'MAIL_DIFF: zero rows means pass; deliver/expire normalized unless @compare_absolute_mail_times=1' AS section;
+SELECT diff_side, receiver, sender, messageType, stationery, money, cod, subject, body,
+       has_items, checked, deliver_time, expire_time, expire_delay, delta_count
+FROM (
+    SELECT 'A_MINUS_B' AS diff_side, a.*, a.row_count - COALESCE(b.row_count, 0) AS delta_count
+    FROM (
+        SELECT receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked,
+               deliver_time, expire_time, expire_delay, COUNT(*) AS row_count
+        FROM custody_diff_mail_a
+        GROUP BY receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked,
+                 deliver_time, expire_time, expire_delay
+    ) a
+    LEFT JOIN (
+        SELECT receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked,
+               deliver_time, expire_time, expire_delay, COUNT(*) AS row_count
+        FROM custody_diff_mail_b
+        GROUP BY receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked,
+                 deliver_time, expire_time, expire_delay
+    ) b
+      ON b.receiver = a.receiver
+     AND b.sender = a.sender
+     AND b.messageType = a.messageType
+     AND b.stationery = a.stationery
+     AND b.money = a.money
+     AND b.cod = a.cod
+     AND b.subject <=> a.subject
+     AND b.body <=> a.body
+     AND b.has_items = a.has_items
+     AND b.checked = a.checked
+     AND b.deliver_time <=> a.deliver_time
+     AND b.expire_time <=> a.expire_time
+     AND b.expire_delay <=> a.expire_delay
+    WHERE a.row_count <> COALESCE(b.row_count, 0)
+    UNION ALL
+    SELECT 'B_MINUS_A' AS diff_side, b.*, b.row_count - COALESCE(a.row_count, 0) AS delta_count
+    FROM (
+        SELECT receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked,
+               deliver_time, expire_time, expire_delay, COUNT(*) AS row_count
+        FROM custody_diff_mail_b
+        GROUP BY receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked,
+                 deliver_time, expire_time, expire_delay
+    ) b
+    LEFT JOIN (
+        SELECT receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked,
+               deliver_time, expire_time, expire_delay, COUNT(*) AS row_count
+        FROM custody_diff_mail_a
+        GROUP BY receiver, sender, messageType, stationery, money, cod, subject, body, has_items, checked,
+                 deliver_time, expire_time, expire_delay
+    ) a
+      ON a.receiver = b.receiver
+     AND a.sender = b.sender
+     AND a.messageType = b.messageType
+     AND a.stationery = b.stationery
+     AND a.money = b.money
+     AND a.cod = b.cod
+     AND a.subject <=> b.subject
+     AND a.body <=> b.body
+     AND a.has_items = b.has_items
+     AND a.checked = b.checked
+     AND a.deliver_time <=> b.deliver_time
+     AND a.expire_time <=> b.expire_time
+     AND a.expire_delay <=> b.expire_delay
+    WHERE b.row_count <> COALESCE(a.row_count, 0)
+) d
+ORDER BY receiver, money, subject, diff_side;
+
+-- Diagnostic: MAIL_ITEMS_DIFF joins mail_id directly (per the idle MAX(mail.id)
+-- snapshot precondition). If MAIL_DIFF is clean but this section is NOT, mail.id
+-- drifted between the clones -- re-verify the idle-snapshot precondition.
+SELECT 'MAIL_ITEMS_DIFF: zero rows means pass (clean MAIL_DIFF + dirty here => mail.id drift)' AS section;
+SELECT diff_side, mail_id, item_guid, item_template, receiver, delta_count
+FROM (
+    SELECT 'A_MINUS_B' AS diff_side, a.*, a.row_count - COALESCE(b.row_count, 0) AS delta_count
+    FROM (
+        SELECT mail_id, item_guid, item_template, receiver, COUNT(*) AS row_count
+        FROM custody_diff_mail_items_a
+        GROUP BY mail_id, item_guid, item_template, receiver
+    ) a
+    LEFT JOIN (
+        SELECT mail_id, item_guid, item_template, receiver, COUNT(*) AS row_count
+        FROM custody_diff_mail_items_b
+        GROUP BY mail_id, item_guid, item_template, receiver
+    ) b
+      ON b.mail_id = a.mail_id
+     AND b.item_guid = a.item_guid
+     AND b.item_template = a.item_template
+     AND b.receiver = a.receiver
+    WHERE a.row_count <> COALESCE(b.row_count, 0)
+    UNION ALL
+    SELECT 'B_MINUS_A' AS diff_side, b.*, b.row_count - COALESCE(a.row_count, 0) AS delta_count
+    FROM (
+        SELECT mail_id, item_guid, item_template, receiver, COUNT(*) AS row_count
+        FROM custody_diff_mail_items_b
+        GROUP BY mail_id, item_guid, item_template, receiver
+    ) b
+    LEFT JOIN (
+        SELECT mail_id, item_guid, item_template, receiver, COUNT(*) AS row_count
+        FROM custody_diff_mail_items_a
+        GROUP BY mail_id, item_guid, item_template, receiver
+    ) a
+      ON a.mail_id = b.mail_id
+     AND a.item_guid = b.item_guid
+     AND a.item_template = b.item_template
+     AND a.receiver = b.receiver
+    WHERE b.row_count <> COALESCE(a.row_count, 0)
+) d
+ORDER BY receiver, item_guid, diff_side;
+
+SELECT 'ITEM_INSTANCE_DIFF: zero rows means pass' AS section;
+SELECT 'A_MINUS_B' AS diff_side, a.guid, a.owner_guid
+FROM custody_diff_item_instance_a a
+LEFT JOIN custody_diff_item_instance_b b
+  ON b.guid = a.guid AND b.owner_guid = a.owner_guid
+WHERE b.guid IS NULL
+UNION ALL
+SELECT 'B_MINUS_A' AS diff_side, b.guid, b.owner_guid
+FROM custody_diff_item_instance_b b
+LEFT JOIN custody_diff_item_instance_a a
+  ON a.guid = b.guid AND a.owner_guid = b.owner_guid
+WHERE a.guid IS NULL
+ORDER BY guid, diff_side;
+
+SELECT 'AUCTION_DIFF: zero rows means pass' AS section;
+SELECT diff_side, id, houseid, itemguid, item_template, item_count, item_randompropertyid,
+       itemowner, buyoutprice, time, buyguid, lastbid, startbid, deposit, delta_count
+FROM (
+    SELECT 'A_MINUS_B' AS diff_side, a.*, a.row_count - COALESCE(b.row_count, 0) AS delta_count
+    FROM (
+        SELECT id, houseid, itemguid, item_template, item_count, item_randompropertyid,
+               itemowner, buyoutprice, time, buyguid, lastbid, startbid, deposit, COUNT(*) AS row_count
+        FROM custody_diff_auction_a
+        GROUP BY id, houseid, itemguid, item_template, item_count, item_randompropertyid,
+                 itemowner, buyoutprice, time, buyguid, lastbid, startbid, deposit
+    ) a
+    LEFT JOIN (
+        SELECT id, houseid, itemguid, item_template, item_count, item_randompropertyid,
+               itemowner, buyoutprice, time, buyguid, lastbid, startbid, deposit, COUNT(*) AS row_count
+        FROM custody_diff_auction_b
+        GROUP BY id, houseid, itemguid, item_template, item_count, item_randompropertyid,
+                 itemowner, buyoutprice, time, buyguid, lastbid, startbid, deposit
+    ) b
+      ON b.id = a.id
+     AND b.houseid = a.houseid
+     AND b.itemguid = a.itemguid
+     AND b.item_template = a.item_template
+     AND b.item_count = a.item_count
+     AND b.item_randompropertyid = a.item_randompropertyid
+     AND b.itemowner = a.itemowner
+     AND b.buyoutprice = a.buyoutprice
+     AND b.time <=> a.time
+     AND b.buyguid = a.buyguid
+     AND b.lastbid = a.lastbid
+     AND b.startbid = a.startbid
+     AND b.deposit = a.deposit
+    WHERE a.row_count <> COALESCE(b.row_count, 0)
+    UNION ALL
+    SELECT 'B_MINUS_A' AS diff_side, b.*, b.row_count - COALESCE(a.row_count, 0) AS delta_count
+    FROM (
+        SELECT id, houseid, itemguid, item_template, item_count, item_randompropertyid,
+               itemowner, buyoutprice, time, buyguid, lastbid, startbid, deposit, COUNT(*) AS row_count
+        FROM custody_diff_auction_b
+        GROUP BY id, houseid, itemguid, item_template, item_count, item_randompropertyid,
+                 itemowner, buyoutprice, time, buyguid, lastbid, startbid, deposit
+    ) b
+    LEFT JOIN (
+        SELECT id, houseid, itemguid, item_template, item_count, item_randompropertyid,
+               itemowner, buyoutprice, time, buyguid, lastbid, startbid, deposit, COUNT(*) AS row_count
+        FROM custody_diff_auction_a
+        GROUP BY id, houseid, itemguid, item_template, item_count, item_randompropertyid,
+                 itemowner, buyoutprice, time, buyguid, lastbid, startbid, deposit
+    ) a
+      ON a.id = b.id
+     AND a.houseid = b.houseid
+     AND a.itemguid = b.itemguid
+     AND a.item_template = b.item_template
+     AND a.item_count = b.item_count
+     AND a.item_randompropertyid = b.item_randompropertyid
+     AND a.itemowner = b.itemowner
+     AND a.buyoutprice = b.buyoutprice
+     AND a.time <=> b.time
+     AND a.buyguid = b.buyguid
+     AND a.lastbid = b.lastbid
+     AND a.startbid = b.startbid
+     AND a.deposit = b.deposit
+    WHERE b.row_count <> COALESCE(a.row_count, 0)
+) d
+ORDER BY id, diff_side;

--- a/World/Updates/Rel22/Rel22_05_003_AH_Repair_Command.sql
+++ b/World/Updates/Rel22/Rel22_05_003_AH_Repair_Command.sql
@@ -29,7 +29,7 @@ BEGIN
     SET @cNewDescription = 'AH_Repair_Command';
 
                         -- COMMENT is 150 Characters MAX
-    SET @cNewComment = 'Add .ah repair console command for custody-ledger drift dry-run and explicit apply repair.';
+    SET @cNewComment = 'Add ah repair console command for custody-ledger drift dry-run and explicit apply repair.';
 
     -- Evaluate all settings
     SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
@@ -48,8 +48,8 @@ BEGIN
     -- token. Scope is custody-ledger drift only, not legacy tear repair.
 
     INSERT INTO `command` (`command_text`, `security`, `help_text`) VALUES
-    ('ah',3,'Syntax: .ah console show|hide\r\nSyntax: .ah repair [--dry-run|apply]\r\n\r\nOut-of-process Auction House service-worker management and custody-ledger repair (server console only).'),
-    ('ah repair',3,'Syntax: .ah repair [--dry-run|apply]\r\n\r\nDry-run or repair supported Auction House custody-ledger drift. Usable only from the server console. Scope is custody-ledger drift only; legacy tears are not repaired.')
+    ('ah',3,'Syntax: ah console show|hide\r\nSyntax: ah repair [--dry-run|apply|force-forfeit <key>]\r\n\r\nOut-of-process Auction House service-worker management and custody-ledger repair (server console only).'),
+    ('ah repair',3,'Syntax: ah repair [--dry-run|apply|force-forfeit <key>]\r\n\r\nDry-run or terminalize supported Auction House custody-ledger drift. Usable only from the server console. Gold is not disbursed by repair; force-forfeit is for human-verified row cleanup. Scope is custody-ledger drift only; legacy tears are not repaired.')
     ON DUPLICATE KEY UPDATE
         `security` = VALUES(`security`),
         `help_text` = VALUES(`help_text`);
@@ -106,4 +106,3 @@ CALL update_mangos();
 
 -- Drop the procedure
 DROP PROCEDURE IF EXISTS `update_mangos`;
-

--- a/World/Updates/Rel22/Rel22_05_003_AH_Repair_Command.sql
+++ b/World/Updates/Rel22/Rel22_05_003_AH_Repair_Command.sql
@@ -1,0 +1,109 @@
+-- ----------------------------------------------------------------
+-- This is an attempt to create a full transactional MaNGOS update
+-- Now compatible with newer MySql Databases (v1.5)
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+    -- Current Values (TODO - must be a better way to do this)
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+
+    -- Expected Values
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '05';
+    SET @cOldContent = '002';
+
+    -- New Values
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '05';
+    SET @cNewContent = '003';
+                            -- DESCRIPTION IS 30 Characters MAX
+    SET @cNewDescription = 'AH_Repair_Command';
+
+                        -- COMMENT is 150 Characters MAX
+    SET @cNewComment = 'Add .ah repair console command for custody-ledger drift dry-run and explicit apply repair.';
+
+    -- Evaluate all settings
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @oldResult := (SELECT `description` FROM `db_version` WHERE `version`=@cOldVersion AND `structure`=@cOldStructure AND `content`=@cOldContent);
+    SET @newResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+    IF (@cCurResult = @oldResult) THEN    -- Does the current version match the expected version
+        -- APPLY UPDATE
+        START TRANSACTION;
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL BELOW -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+    -- Register the custody-ledger repair command. The handler is
+    -- SERVER-CONSOLE-ONLY and defaults to dry-run; apply requires an explicit
+    -- token. Scope is custody-ledger drift only, not legacy tear repair.
+
+    INSERT INTO `command` (`command_text`, `security`, `help_text`) VALUES
+    ('ah',3,'Syntax: .ah console show|hide\r\nSyntax: .ah repair [--dry-run|apply]\r\n\r\nOut-of-process Auction House service-worker management and custody-ledger repair (server console only).'),
+    ('ah repair',3,'Syntax: .ah repair [--dry-run|apply]\r\n\r\nDry-run or repair supported Auction House custody-ledger drift. Usable only from the server console. Scope is custody-ledger drift only; legacy tears are not repaired.')
+    ON DUPLICATE KEY UPDATE
+        `security` = VALUES(`security`),
+        `help_text` = VALUES(`help_text`);
+
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL ABOVE -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+        -- If we get here ok, commit the changes
+        IF bRollback = TRUE THEN
+            ROLLBACK;
+            SHOW ERRORS;
+            SELECT '* UPDATE FAILED *' AS `===== Status =====`,@cCurResult AS `===== DB is on Version: =====`;
+        ELSE
+            COMMIT;
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            -- UPDATE THE DB VERSION
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure, @cNewContent, @cNewDescription, @cNewComment);
+            SET @newResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+            SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,@newResult AS `===== DB is now on Version =====`;
+        END IF;
+    ELSE    -- Current version is not the expected version
+        IF (@cCurResult = @newResult) THEN    -- Does the current version match the new version
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cCurResult AS `===== DB is already on Version =====`;
+        ELSE    -- Current version is not one related to this update
+            IF(@cCurResult IS NULL) THEN    -- Something has gone wrong
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                IF(@oldResult IS NULL) THEN    -- Something has gone wrong
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SET @oldResult = CONCAT('Rel',@cOldVersion, '_', @cOldStructure, '_', @cOldContent, ' - ','IS NOT APPLIED');
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@oldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                ELSE
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@oldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;
+

--- a/World/Updates/Rel22/Rel22_05_005_AH_Repair_Command.sql
+++ b/World/Updates/Rel22/Rel22_05_005_AH_Repair_Command.sql
@@ -19,12 +19,12 @@ BEGIN
     -- Expected Values
     SET @cOldVersion = '22';
     SET @cOldStructure = '05';
-    SET @cOldContent = '002';
+    SET @cOldContent = '004';
 
     -- New Values
     SET @cNewVersion = '22';
     SET @cNewStructure = '05';
-    SET @cNewContent = '003';
+    SET @cNewContent = '005';
                             -- DESCRIPTION IS 30 Characters MAX
     SET @cNewDescription = 'AH_Repair_Command';
 


### PR DESCRIPTION
The database half of the AH-subprocess Phase 2 work. **Paired with the server PR
— this must merge first**, or a server built from that PR fails its Character-DB
version check (it requires `custody_ledger` / `22_05_001`). Same pairing as
Phase 1 (this repo #151 ↔ server #392).

### Changes (3 files, +585)
- **`Character/Updates/Rel22/Rel22_05_001_Add_Custody_Ledger_Table.sql`** — the
  in-mangosd custody/escrow ledger table (`custody_ledger`) that records every
  unit of value in flight for the player AH seams. Bumps the Character DB to
  structure 5 (`Add_Custody_Ledger_Table`).
- **`World/Updates/Rel22/Rel22_05_005_AH_Repair_Command.sql`** — registers the
  server-console-only `ah repair` custody-drift command. Chains after the current
  World tip `22_05_004`; renumbered from `_003` to avoid a collision with the
  already-merged #152 `ItemAndSkinGroupFix`.
- **`Tools/custody_diff.sql`** — the player-visible differential diagnostic
  (relocated here from the server repo, where SQL didn't belong). Diffs two
  Character-DB clones (`AH.Service.Custody` off vs on) to prove byte-identical
  parity before any promotion flip; referenced by the custody promotion runbook.

### Testing
Both migrations use the standard idempotent/version-gated `update_mangos()`
proc: first apply prints `* UPDATE COMPLETE *`, a re-run prints
`* UPDATE SKIPPED *`. Applied in order the World DB reaches tip `22/5/5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/database/153)
<!-- Reviewable:end -->
