### PR TITLE
feat(command): .ticket payload help rows (Rel22_05_006)

### DIFF
--- a/World/Updates/Rel22/Rel22_05_006_Ticket_Payload_Commands.sql
+++ b/World/Updates/Rel22/Rel22_05_006_Ticket_Payload_Commands.sql
@@ -1,0 +1,110 @@
+-- ----------------------------------------------------------------
+-- This is an attempt to create a full transactional MaNGOS update
+-- Now compatible with newer MySql Databases (v1.5)
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+    -- Current Values (TODO - must be a better way to do this)
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+
+    -- Expected Values
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '05';
+    SET @cOldContent = '005';
+
+    -- New Values
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '05';
+    SET @cNewContent = '006';
+                            -- DESCRIPTION IS 30 Characters MAX
+    SET @cNewDescription = 'Ticket_Payload_Commands';
+
+                        -- COMMENT is 150 Characters MAX
+    SET @cNewComment = 'Add .ticket payload list/show/ping GM command help rows for the ZeroGM ticket-console addon transport.';
+
+    -- Evaluate all settings
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @oldResult := (SELECT `description` FROM `db_version` WHERE `version`=@cOldVersion AND `structure`=@cOldStructure AND `content`=@cOldContent);
+    SET @newResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+    IF (@cCurResult = @oldResult) THEN    -- Does the current version match the expected version
+        -- APPLY UPDATE
+        START TRANSACTION;
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL BELOW -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+    -- Register the .ticket payload subcommands (defined in
+    -- src/game/ChatCommands/GMTicketCommands.cpp, table in Chat.cpp). They are
+    -- read-only and push the open GM ticket queue to the requesting GM's own
+    -- session over the addon channel, for the ZeroGM ticket-console addon. The
+    -- `ticket payload` group row plus each leaf gives .help a description at every
+    -- level; security 2 (GAMEMASTER) matches the in-code SEC_GAMEMASTER gate and
+    -- the sibling `ticket close|list|show` rows.
+    INSERT INTO `command` (`command_text`, `security`, `help_text`) VALUES
+    ('ticket payload',2,'Syntax: .ticket payload list|show|ping\r\n\r\nZeroGM ticket-console transport: push the open GM ticket queue to your addon over the addon channel. Read-only.'),
+    ('ticket payload list',2,'Syntax: .ticket payload list\r\n\r\nPush the open GM ticket queue (id, player, age, online, text snippet) to your ZeroGM addon.'),
+    ('ticket payload show',2,'Syntax: .ticket payload show (#ID|$name)\r\n\r\nPush the full detail of one ticket plus the reporter location to your ZeroGM addon.'),
+    ('ticket payload ping',2,'Syntax: .ticket payload ping\r\n\r\nSend a ZeroGM addon-transport diagnostic frame to yourself, for testing the ticket-console link.');
+
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL ABOVE -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+        -- If we get here ok, commit the changes
+        IF bRollback = TRUE THEN
+            ROLLBACK;
+            SHOW ERRORS;
+            SELECT '* UPDATE FAILED *' AS `===== Status =====`,@cCurResult AS `===== DB is on Version: =====`;
+        ELSE
+            COMMIT;
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            -- UPDATE THE DB VERSION
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure, @cNewContent, @cNewDescription, @cNewComment);
+            SET @newResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+            SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,@newResult AS `===== DB is now on Version =====`;
+        END IF;
+    ELSE    -- Current version is not the expected version
+        IF (@cCurResult = @newResult) THEN    -- Does the current version match the new version
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cCurResult AS `===== DB is already on Version =====`;
+        ELSE    -- Current version is not one related to this update
+            IF(@cCurResult IS NULL) THEN    -- Something has gone wrong
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                IF(@oldResult IS NULL) THEN    -- Something has gone wrong
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SET @oldResult = CONCAT('Rel',@cOldVersion, '_', @cOldStructure, '_', @cOldContent, ' - ','IS NOT APPLIED');
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@oldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                ELSE
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@oldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;


### PR DESCRIPTION
## What
Adds `command`-table help rows for the new read-only `.ticket payload {list|show|ping}` GM subcommands from the server ticket-console feature. Update `Rel22_05_006`, chained `22/05/005 → 22/05/006`.

## Why
The server registers `.ticket payload` (`GMTicketCommands.cpp` / `Chat.cpp`) to push the open GM ticket queue to a GM's ZeroGM addon over the addon channel. The commands are already gated in code (`SEC_GAMEMASTER`); this gives `.help` a description at each level and keeps the `command` table complete.

## Details
- Four rows at security **2 (GAMEMASTER)** — matching the code gate and the sibling `ticket close|list|show` rows: `ticket payload` (group), `ticket payload list`, `ticket payload show`, `ticket payload ping`.
- Standard transactional `update_mangos` template (clone of `Rel22_05_002`); FullDB dump untouched (regenerated per convention). Read-only commands, no schema change.

## Pairs with
Server PR *feat(ticket): .ticket payload subcommands*. The commands function without this update (code-enforced security); this adds their help text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/database/155)
<!-- Reviewable:end -->
