### PR TITLE
AH subprocess Phase 2 DB: worker journal and AH command metadata

### DIFF
--- a/Character/Updates/Rel22/Rel22_05_002_Add_Ah_Worker_Journal.sql
+++ b/Character/Updates/Rel22/Rel22_05_002_Add_Ah_Worker_Journal.sql
@@ -1,0 +1,111 @@
+-- ----------------------------------------------------------------
+-- This is an attempt to create a full transactional MaNGOS update
+-- Now compatible with newer MySql Databases (v1.5)
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+    -- Current Values (TODO - must be a better way to do this)
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+
+    -- Expected Values
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '05';
+    SET @cOldContent = '001';
+
+    -- New Values
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '05';
+    SET @cNewContent = '002';
+                            -- DESCRIPTION IS 30 Characters MAX
+    SET @cNewDescription = 'Add_Ah_Worker_Journal';
+
+                        -- COMMENT is 150 Characters MAX
+    SET @cNewComment = 'SP-2 worker mutation journal/outbox';
+
+    -- Evaluate all settings
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @oldResult := (SELECT `description` FROM `db_version` WHERE `version`=@cOldVersion AND `structure`=@cOldStructure AND `content`=@cOldContent);
+    SET @newResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+    IF (@cCurResult = @oldResult) THEN    -- Does the current version match the expected version
+        -- APPLY UPDATE
+        START TRANSACTION;
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL BELOW -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+    DROP TABLE IF EXISTS `ah_worker_journal`;
+    CREATE TABLE `ah_worker_journal` (
+        `uuid`          BIGINT(20) UNSIGNED NOT NULL,
+        `auction_id`    INT(10) UNSIGNED NOT NULL DEFAULT '0',
+        `kind`          TINYINT(3) UNSIGNED NOT NULL,
+        `state`         TINYINT(3) UNSIGNED NOT NULL,
+        `facts`         BLOB,
+        `created_time`  BIGINT(20) NOT NULL DEFAULT '0',
+        `resolved_time` BIGINT(20) NOT NULL DEFAULT '0',
+        PRIMARY KEY (`uuid`),
+        KEY `idx_state` (`state`),
+        KEY `idx_auction` (`auction_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL ABOVE -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+        -- If we get here ok, commit the changes
+        IF bRollback = TRUE THEN
+            ROLLBACK;
+            SHOW ERRORS;
+            SELECT '* UPDATE FAILED *' AS `===== Status =====`,@cCurResult AS `===== DB is on Version: =====`;
+        ELSE
+            COMMIT;
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            -- UPDATE THE DB VERSION
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure, @cNewContent, @cNewDescription, @cNewComment);
+            SET @newResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+            SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,@newResult AS `===== DB is now on Version =====`;
+        END IF;
+    ELSE    -- Current version is not the expected version
+        IF (@cCurResult = @newResult) THEN    -- Does the current version match the new version
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cCurResult AS `===== DB is already on Version =====`;
+        ELSE    -- Current version is not one related to this update
+            IF(@cCurResult IS NULL) THEN    -- Something has gone wrong
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                IF(@oldResult IS NULL) THEN    -- Something has gone wrong
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SET @oldResult = CONCAT('Rel',@cOldVersion, '_', @cOldStructure, '_', @cOldContent, ' - ','IS NOT APPLIED');
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@oldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                ELSE
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@oldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;

--- a/World/Updates/Rel22/Rel22_05_006_AH_Command_Metadata_Cleanup.sql
+++ b/World/Updates/Rel22/Rel22_05_006_AH_Command_Metadata_Cleanup.sql
@@ -1,0 +1,117 @@
+-- ----------------------------------------------------------------
+-- This is an attempt to create a full transactional MaNGOS update
+-- Now compatible with newer MySql Databases (v1.5)
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+    -- Current Values (TODO - must be a better way to do this)
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+
+    -- Expected Values
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '05';
+    SET @cOldContent = '005';
+
+    -- New Values
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '05';
+    SET @cNewContent = '006';
+                            -- DESCRIPTION IS 30 Characters MAX
+    SET @cNewDescription = 'AH_Command_Metadata_Cleanup';
+
+                        -- COMMENT is 150 Characters MAX
+    SET @cNewComment = 'Clean duplicate AH command metadata and keep only executable AH command rows.';
+
+    -- Evaluate all settings
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+    SET @oldResult := (SELECT `description` FROM `db_version` WHERE `version`=@cOldVersion AND `structure`=@cOldStructure AND `content`=@cOldContent);
+    SET @newResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+    IF (@cCurResult = @oldResult) THEN    -- Does the current version match the expected version
+        -- APPLY UPDATE
+        START TRANSACTION;
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL BELOW -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+    DELETE FROM `locales_command`
+    WHERE `id` IN (
+        SELECT `id`
+        FROM `command`
+        WHERE `command_text` IN ('ah', 'ah console', 'ah console show', 'ah console hide', 'ah repair')
+    );
+
+    DELETE FROM `command`
+    WHERE `command_text` IN ('ah', 'ah console', 'ah console show', 'ah console hide', 'ah repair');
+
+    INSERT INTO `command` (`command_text`, `security`, `help_text`) VALUES
+    ('ah console show',3,'Syntax: ah console show\r\n\r\nShow the out-of-process AH service-worker console window. Usable only from the server console, not in-game.'),
+    ('ah console hide',3,'Syntax: ah console hide\r\n\r\nHide the out-of-process AH service-worker console window. Usable only from the server console, not in-game.'),
+    ('ah repair',3,'Syntax: ah repair [--dry-run|apply|force-forfeit <key>]\r\n\r\nDry-run or terminalize supported Auction House custody-ledger drift. Usable only from the server console. Gold is not disbursed by repair; force-forfeit is for human-verified row cleanup. Scope is custody-ledger drift only; legacy tears are not repaired.');
+
+    INSERT INTO `locales_command` (`id`)
+    SELECT `id`
+    FROM `command`
+    WHERE `command_text` IN ('ah console show', 'ah console hide', 'ah repair');
+
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+        -- -- PLACE UPDATE SQL ABOVE -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+        -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+
+        -- If we get here ok, commit the changes
+        IF bRollback = TRUE THEN
+            ROLLBACK;
+            SHOW ERRORS;
+            SELECT '* UPDATE FAILED *' AS `===== Status =====`,@cCurResult AS `===== DB is on Version: =====`;
+        ELSE
+            COMMIT;
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            -- UPDATE THE DB VERSION
+            -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
+            INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure, @cNewContent, @cNewDescription, @cNewComment);
+            SET @newResult := (SELECT `description` FROM `db_version` WHERE `version`=@cNewVersion AND `structure`=@cNewStructure AND `content`=@cNewContent);
+
+            SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,@newResult AS `===== DB is now on Version =====`;
+        END IF;
+    ELSE    -- Current version is not the expected version
+        IF (@cCurResult = @newResult) THEN    -- Does the current version match the new version
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@cCurResult AS `===== DB is already on Version =====`;
+        ELSE    -- Current version is not one related to this update
+            IF(@cCurResult IS NULL) THEN    -- Something has gone wrong
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                IF(@oldResult IS NULL) THEN    -- Something has gone wrong
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SET @oldResult = CONCAT('Rel',@cOldVersion, '_', @cOldStructure, '_', @cOldContent, ' - ','IS NOT APPLIED');
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@oldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                ELSE
+                    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurStructure := (SELECT `STRUCTURE` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurContent := (SELECT `Content` FROM `db_version` ORDER BY `version` DESC, `STRUCTURE` DESC, `CONTENT` DESC LIMIT 0,1);
+                    SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure, '_', @cCurContent, ' - ',@cCurResult);
+                    SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,@oldResult AS `=== Expected ===`,@cCurOutput AS `===== Found Version =====`;
+                END IF;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;


### PR DESCRIPTION
## Summary

Adds the database side required for AH subprocess Phase 2 write-authority.

This PR must land with the companion server PR, and its migrations must be applied before enabling `AH.Service.WriteAuthority = 1`.

## Key Changes

- Adds Character DB migration for `ah_worker_journal`.
- Adds World DB command metadata cleanup for AH console/repair commands.
- Ensures the core can require the DB version containing the AH command metadata update.

## Deployment Notes

Apply these DB updates before enabling AH worker write-authority.

The server-side write-authority path force-disables itself when the required worker journal table is missing, because reconcile-on-reconnect depends on `ah_worker_journal`.

## Validation

- Applied migrations to the AH test databases.
- Verified DB version gates match server expectations.
- Verified AH command metadata rows are present and de-duplicated:
  - `ah console show`
  - `ah console hide`
  - `ah repair`
- Live SP-2 smoke passed with the companion server branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/database/156)
<!-- Reviewable:end -->
