### PR TITLE
Replace legacy Warden database tables

### DIFF
--- a/Character/Updates/Rel22/Rel22_05_004_Remove_Warden_Action.sql
+++ b/Character/Updates/Rel22/Rel22_05_004_Remove_Warden_Action.sql
@@ -1,0 +1,77 @@
+-- ----------------------------------------------------------------
+-- Remove obsolete per-check Warden punishment overrides.
+-- IMPORTANT: export any custom `warden_action` rows before applying this
+-- intentionally destructive update. No automatic conversion is safe.
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        SHOW ERRORS;
+        SELECT '* UPDATE FAILED *' AS `===== Status =====`,
+               @cCurResult AS `===== DB is on Version: =====`;
+        RESIGNAL;
+    END;
+
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '05';
+    SET @cOldContent = '003';
+
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '05';
+    SET @cNewContent = '004';
+    SET @cNewDescription = 'Remove_Warden_Action';
+    SET @cNewComment = 'Remove obsolete per-check Warden punishments';
+
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cOldResult := (SELECT `description` FROM `db_version` WHERE `version` = @cOldVersion AND `structure` = @cOldStructure AND `content` = @cOldContent);
+    SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version` = @cNewVersion AND `structure` = @cNewStructure AND `content` = @cNewContent);
+
+    IF (@cCurResult = @cOldResult) THEN
+        START TRANSACTION;
+        DROP TABLE IF EXISTS `warden_action`;
+
+        INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure,
+            @cNewContent, @cNewDescription, @cNewComment);
+        SET @cNewResult := (SELECT `description` FROM `db_version`
+            WHERE `version` = @cNewVersion AND `structure` = @cNewStructure
+              AND `content` = @cNewContent);
+        COMMIT;
+        SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,
+               @cNewResult AS `===== DB is now on Version =====`;
+    ELSE
+        IF (@cCurResult = @cNewResult) THEN
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,
+                   @cCurResult AS `===== DB is already on Version =====`;
+        ELSE
+            IF (@cCurResult IS NULL) THEN
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,
+                       'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure,
+                    '_', @cCurContent, ' - ', @cCurResult);
+                SET @cOldOutput = CONCAT(@cOldVersion, '_', @cOldStructure,
+                    '_', @cOldContent, ' - ',
+                    COALESCE(@cOldResult, 'IS NOT APPLIED'));
+                SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,
+                       @cOldOutput AS `=== Expected ===`,
+                       @cCurOutput AS `===== Found Version =====`;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+CALL update_mangos();
+
+DROP PROCEDURE IF EXISTS `update_mangos`;

--- a/InstallDatabases.sh
+++ b/InstallDatabases.sh
@@ -193,15 +193,17 @@ updateWorldDB()
     printf "Updating data into the World database ${wdb}\n"
     for file in World/Updates/${OLDRELEASE}/*.sql
     do
+        [ -e "${file}" ] || continue
         printf "Applying update ${file}\n"
-        ${dbcommand} "${wdb}" < "${file}"
+        ${dbcommand} "${wdb}" < "${file}" || return 1
         printf "File ${file} imported\n"
     done
 
     for file in World/Updates/${RELEASE}/*.sql
     do
+        [ -e "${file}" ] || continue
         printf "Applying update ${file}\n"
-        ${dbcommand} "${wdb}" < "${file}"
+        ${dbcommand} "${wdb}" < "${file}" || return 1
         printf "File ${file} imported\n"
     done
 }
@@ -229,7 +231,7 @@ updateRealmDB()
 	do
 		file=$(echo ${file} | tr '|' ' ')
 		printf "Applying update ${file}\n"
-		$(${dbcommand} ${rdb} < ${file})
+		${dbcommand} "${rdb}" < "${file}" || return 1
 		printf "File ${file} imported\n"
 	done
 
@@ -237,7 +239,7 @@ updateRealmDB()
 	do
 		file=$(echo ${file} | tr '|' ' ')
 		printf "Applying update ${file}\n"
-		$(${dbcommand} ${rdb} < ${file})
+		${dbcommand} "${rdb}" < "${file}" || return 1
 		printf "File ${file} imported\n"
 	done
 }
@@ -433,11 +435,17 @@ if [ "${updatecharDB}" = "YES" ]; then
 fi
 
 if [ "${updateworldDB}" = "YES" ]; then
-	updateWorldDB
+	if ! updateWorldDB; then
+		printf "World database update failed.\n"
+		exit 1
+	fi
 fi
 
 if [ "${updaterealmDB}" = "YES" ]; then
-	updateRealmDB
+	if ! updateRealmDB; then
+		printf "Realm database update failed.\n"
+		exit 1
+	fi
 fi
 
 if [ "${addRealmList}" = "YES" ]; then

--- a/InstallDatabases.sh
+++ b/InstallDatabases.sh
@@ -135,7 +135,7 @@ updateCharDB()
 	do
 		file=$(echo ${file} | tr '|' ' ')
 		printf "Applying update ${file}\n"
-		${dbcommand} "${cdb}" < "${file}"
+		${dbcommand} "${cdb}" < "${file}" || return 1
 		printf "File ${file} imported\n"
 	done
 
@@ -143,7 +143,7 @@ updateCharDB()
 	do
 		file=$(echo ${file} | tr '|' ' ')
 		printf "Applying update ${file}\n"
-		${dbcommand} "${cdb}" < "${file}"
+		${dbcommand} "${cdb}" < "${file}" || return 1
 		printf "File ${file} imported\n"
 	done
 }
@@ -426,7 +426,10 @@ if [ "${createrealmDB}" = "YES" ]; then
 fi
 
 if [ "${updatecharDB}" = "YES" ]; then
-	updateCharDB
+	if ! updateCharDB; then
+		printf "Character database update failed.\n"
+		exit 1
+	fi
 fi
 
 if [ "${updateworldDB}" = "YES" ]; then

--- a/InstallDatabases.sh
+++ b/InstallDatabases.sh
@@ -126,10 +126,6 @@ loadCharDB()
 {
 	printf "Loading data into character database ${cdb}\n"
 	$(${dbcommand} ${cdb} < Character/Setup/characterLoadDB.sql)
-
-	if [ "${updatecharDB}" = "YES" ]; then
-		updateCharDB
-	fi
 }
 
 updateCharDB()
@@ -427,6 +423,10 @@ fi
 
 if [ "${createrealmDB}" = "YES" ]; then
 	createRealmDB
+fi
+
+if [ "${updatecharDB}" = "YES" ]; then
+	updateCharDB
 fi
 
 if [ "${updateworldDB}" = "YES" ]; then

--- a/Tools/backupDB.cmd
+++ b/Tools/backupDB.cmd
@@ -1501,9 +1501,7 @@ if %loadworldDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_worlddb\%TAB
 if %loadworldDB% == NO echo -- ---------------------------------------- >>  _full_worlddb\%TABLENAME%.sql
 mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %wdb% %TABLENAME% >>  _full_worlddb\%TABLENAME%.sql
 
-call :DumpOptionalTable "%wdb%" "_full_worlddb" "%loadworldDB%" "warden"
-if errorlevel 1 goto error
-call :DumpOptionalTable "%wdb%" "_full_worlddb" "%loadworldDB%" "warden_checks"
+call :DumpOptionalGroup "%wdb%" "_full_worlddb" "%loadworldDB%" "YES" "warden" "warden_checks"
 if errorlevel 1 goto error
 
 goto CharDB:
@@ -2106,7 +2104,7 @@ if %loadcharDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_chardb\%TABLE
 if %loadcharDB% == NO echo -- ---------------------------------------- >>  _full_chardb\%TABLENAME%.sql
 mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %cdb% %TABLENAME% >>  _full_chardb\%TABLENAME%.sql
 
-call :DumpOptionalTable "%cdb%" "_full_chardb" "%loadcharDB%" "warden_action"
+call :DumpOptionalGroup "%cdb%" "_full_chardb" "%loadcharDB%" "NO" "warden_action"
 if errorlevel 1 goto error
 goto RealmDB:
 
@@ -2186,29 +2184,106 @@ if %loadrealmDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_realmdb\%TAB
 if %loadrealmDB% == NO echo -- ---------------------------------------- >>  _full_realmdb\%TABLENAME%.sql
 mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %rdb% %TABLENAME% >>  _full_realmdb\%TABLENAME%.sql
 
-call :DumpOptionalTable "%rdb%" "_full_realmdb" "%loadrealmDB%" "warden_log"
-if errorlevel 1 goto error
-call :DumpOptionalTable "%rdb%" "_full_realmdb" "%loadrealmDB%" "warden_incident"
-if errorlevel 1 goto error
-call :DumpOptionalTable "%rdb%" "_full_realmdb" "%loadrealmDB%" "warden_audit"
+call :DumpOptionalGroup "%rdb%" "_full_realmdb" "%loadrealmDB%" "YES" "warden_log" "warden_incident" "warden_audit"
 if errorlevel 1 goto error
 
 goto done:
 
-:DumpOptionalTable
-setlocal
+:DumpOptionalGroup
+setlocal EnableExtensions EnableDelayedExpansion
 set "OPTIONALDB=%~1"
 set "OPTIONALDIR=%~2"
 set "OPTIONALSTRUCTURE=%~3"
-set "OPTIONALTABLE=%~4"
-set "OPTIONALOUTPUT=%OPTIONALDIR%\%OPTIONALTABLE%.sql"
+set "OPTIONALRETAINEMPTY=%~4"
+set "OPTIONALPRESENT=0"
+set "OPTIONALFAILED=0"
+
+for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
+    for %%S in (exists.tmp dump.tmp sql.new present.tmp absent.tmp) do (
+        if exist "!OPTIONALDIR!\%%~T.%%S" del /Q "!OPTIONALDIR!\%%~T.%%S"
+        if exist "!OPTIONALDIR!\%%~T.%%S" set "OPTIONALFAILED=1"
+    )
+)
+if "!OPTIONALFAILED!" == "1" goto DumpOptionalGroupFailed
+
+rem Phase 1: probe every member before staging any member.
+for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
+    if "!OPTIONALFAILED!" == "0" (
+        call :ProbeOptionalTable "!OPTIONALDB!" "!OPTIONALDIR!" "%%~T"
+        if errorlevel 1 set "OPTIONALFAILED=1"
+    )
+)
+if "!OPTIONALFAILED!" == "1" goto DumpOptionalGroupFailed
+
+for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
+    if exist "!OPTIONALDIR!\%%~T.present.tmp" set "OPTIONALPRESENT=1"
+)
+if "!OPTIONALPRESENT!" == "0" if /I "!OPTIONALRETAINEMPTY!" == "YES" goto DumpOptionalGroupRetainEmpty
+
+rem Phase 2: stage every member proven present.
+for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
+    if "!OPTIONALFAILED!" == "0" if exist "!OPTIONALDIR!\%%~T.present.tmp" (
+        call :StageOptionalTable "!OPTIONALDB!" "!OPTIONALDIR!" "!OPTIONALSTRUCTURE!" "%%~T"
+        if errorlevel 1 set "OPTIONALFAILED=1"
+    )
+)
+if "!OPTIONALFAILED!" == "1" goto DumpOptionalGroupFailed
+
+rem Phase 3: publish every complete staged member.
+set "OPTIONALFAILED=0"
+for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
+    set "OPTIONALREADY=!OPTIONALDIR!\%%~T.sql.new"
+    set "OPTIONALOUTPUT=!OPTIONALDIR!\%%~T.sql"
+    if "!OPTIONALFAILED!" == "0" if exist "!OPTIONALREADY!" (
+        move /Y "!OPTIONALREADY!" "!OPTIONALOUTPUT!" >nul
+        if errorlevel 1 set "OPTIONALFAILED=1"
+    )
+)
+if "!OPTIONALFAILED!" == "1" goto DumpOptionalGroupFailed
+
+rem Phase 4: only now remove outputs proven absent.
+set "OPTIONALFAILED=0"
+for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
+    if exist "!OPTIONALDIR!\%%~T.absent.tmp" (
+        set "OPTIONALOUTPUT=!OPTIONALDIR!\%%~T.sql"
+        if exist "!OPTIONALOUTPUT!" del /Q "!OPTIONALOUTPUT!"
+        if exist "!OPTIONALOUTPUT!" set "OPTIONALFAILED=1"
+    )
+)
+if "!OPTIONALFAILED!" == "1" goto DumpOptionalGroupFailed
+
+call :CleanupOptionalGroupArtifacts "!OPTIONALDIR!" "%~5" "%~6" "%~7"
+if errorlevel 1 goto DumpOptionalGroupFailed
+endlocal
+exit /b 0
+
+:ProbeOptionalTable
+setlocal EnableExtensions DisableDelayedExpansion
+set "OPTIONALDB=%~1"
+set "OPTIONALDIR=%~2"
+set "OPTIONALTABLE=%~3"
 set "OPTIONALPROBE=%OPTIONALDIR%\%OPTIONALTABLE%.exists.tmp"
-set "OPTIONALTEMP=%OPTIONALDIR%\%OPTIONALTABLE%.dump.tmp"
-set "OPTIONALREADY=%OPTIONALDIR%\%OPTIONALTABLE%.sql.new"
+set "OPTIONALPRESENT=%OPTIONALDIR%\%OPTIONALTABLE%.present.tmp"
+set "OPTIONALABSENT=%OPTIONALDIR%\%OPTIONALTABLE%.absent.tmp"
 
 if exist "%OPTIONALPROBE%" del /Q "%OPTIONALPROBE%"
-if exist "%OPTIONALTEMP%" del /Q "%OPTIONALTEMP%"
-if exist "%OPTIONALREADY%" del /Q "%OPTIONALREADY%"
+if exist "%OPTIONALPROBE%" (
+    echo ERROR: Could not clear probe artifact for %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 1
+)
+if exist "%OPTIONALPRESENT%" del /Q "%OPTIONALPRESENT%"
+if exist "%OPTIONALPRESENT%" (
+    echo ERROR: Could not clear present marker for %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 1
+)
+if exist "%OPTIONALABSENT%" del /Q "%OPTIONALABSENT%"
+if exist "%OPTIONALABSENT%" (
+    echo ERROR: Could not clear absent marker for %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 1
+)
 
 "%mysql%mysql.exe" --batch --skip-column-names -u%user% -p%pass% --port=%port% -h %svr% -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '%OPTIONALDB%' AND table_name = '%OPTIONALTABLE%';" > "%OPTIONALPROBE%" 2>nul
 if errorlevel 1 (
@@ -2221,23 +2296,65 @@ if errorlevel 1 (
 set "OPTIONALFOUND="
 set /p OPTIONALFOUND=<"%OPTIONALPROBE%"
 del /Q "%OPTIONALPROBE%"
-
-if not "%OPTIONALFOUND%" == "0" if not "%OPTIONALFOUND%" == "1" (
-    echo ERROR: Invalid table probe result for %OPTIONALDB%.%OPTIONALTABLE%.
+if exist "%OPTIONALPROBE%" (
+    echo ERROR: Could not clear probe result for %OPTIONALDB%.%OPTIONALTABLE%.
     endlocal
     exit /b 1
 )
 
 if "%OPTIONALFOUND%" == "0" (
-    if exist "%OPTIONALOUTPUT%" del /Q "%OPTIONALOUTPUT%"
-    if exist "%OPTIONALOUTPUT%" (
-        echo ERROR: Could not remove stale backup for %OPTIONALDB%.%OPTIONALTABLE%.
+    type nul > "%OPTIONALABSENT%"
+    if not exist "%OPTIONALABSENT%" (
+        echo ERROR: Could not record absent table %OPTIONALDB%.%OPTIONALTABLE%.
         endlocal
         exit /b 1
     )
     echo Skipping absent optional table %OPTIONALDB%.%OPTIONALTABLE%.
     endlocal
     exit /b 0
+)
+
+if "%OPTIONALFOUND%" == "1" (
+    type nul > "%OPTIONALPRESENT%"
+    if not exist "%OPTIONALPRESENT%" (
+        echo ERROR: Could not record present table %OPTIONALDB%.%OPTIONALTABLE%.
+        endlocal
+        exit /b 1
+    )
+    endlocal
+    exit /b 0
+)
+
+echo ERROR: Invalid table probe result for %OPTIONALDB%.%OPTIONALTABLE%.
+endlocal
+exit /b 1
+
+:StageOptionalTable
+setlocal EnableExtensions DisableDelayedExpansion
+set "OPTIONALDB=%~1"
+set "OPTIONALDIR=%~2"
+set "OPTIONALSTRUCTURE=%~3"
+set "OPTIONALTABLE=%~4"
+set "OPTIONALPRESENT=%OPTIONALDIR%\%OPTIONALTABLE%.present.tmp"
+set "OPTIONALTEMP=%OPTIONALDIR%\%OPTIONALTABLE%.dump.tmp"
+set "OPTIONALREADY=%OPTIONALDIR%\%OPTIONALTABLE%.sql.new"
+
+if not exist "%OPTIONALPRESENT%" (
+    echo ERROR: Missing present marker for %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 1
+)
+if exist "%OPTIONALTEMP%" del /Q "%OPTIONALTEMP%"
+if exist "%OPTIONALTEMP%" (
+    echo ERROR: Could not clear dump artifact for %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 1
+)
+if exist "%OPTIONALREADY%" del /Q "%OPTIONALREADY%"
+if exist "%OPTIONALREADY%" (
+    echo ERROR: Could not clear staged artifact for %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 1
 )
 
 set "OPTIONALPARAMS="
@@ -2247,6 +2364,7 @@ echo             %OPTIONALTABLE%
 "%mysql%mysqldump.exe" -Q -c -e -q %OPTIONALPARAMS% -u%user% -p%pass% --port=%port% -h %svr% %OPTIONALDB% %OPTIONALTABLE% > "%OPTIONALTEMP%"
 if errorlevel 1 (
     if exist "%OPTIONALTEMP%" del /Q "%OPTIONALTEMP%"
+    if exist "%OPTIONALREADY%" del /Q "%OPTIONALREADY%"
     echo ERROR: Could not dump %OPTIONALDB%.%OPTIONALTABLE%.
     endlocal
     exit /b 1
@@ -2254,38 +2372,62 @@ if errorlevel 1 (
 
 if /I "%OPTIONALSTRUCTURE%" == "NO" (
     %ComSpec% /D /C echo -- ---------------------------------------- ^> "%OPTIONALREADY%"
-    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    if errorlevel 1 goto StageOptionalTableAssemblyFailed
     %ComSpec% /D /C echo -- --        CLEAR DOWN THE TABLE        -- ^>^> "%OPTIONALREADY%"
-    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    if errorlevel 1 goto StageOptionalTableAssemblyFailed
     %ComSpec% /D /C echo -- ---------------------------------------- ^>^> "%OPTIONALREADY%"
-    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    if errorlevel 1 goto StageOptionalTableAssemblyFailed
     %ComSpec% /D /C echo TRUNCATE TABLE `%OPTIONALTABLE%`; ^>^> "%OPTIONALREADY%"
-    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    if errorlevel 1 goto StageOptionalTableAssemblyFailed
     %ComSpec% /D /C echo -- ---------------------------------------- ^>^> "%OPTIONALREADY%"
-    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    if errorlevel 1 goto StageOptionalTableAssemblyFailed
     %ComSpec% /D /C type "%OPTIONALTEMP%" ^>^> "%OPTIONALREADY%"
-    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    if errorlevel 1 goto StageOptionalTableAssemblyFailed
     del /Q "%OPTIONALTEMP%"
-    if exist "%OPTIONALTEMP%" goto DumpOptionalTableAssemblyFailed
+    if exist "%OPTIONALTEMP%" goto StageOptionalTableAssemblyFailed
 ) else (
     move /Y "%OPTIONALTEMP%" "%OPTIONALREADY%" >nul
-    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    if errorlevel 1 goto StageOptionalTableAssemblyFailed
 )
 
-move /Y "%OPTIONALREADY%" "%OPTIONALOUTPUT%" >nul
-if errorlevel 1 (
-    echo ERROR: Could not publish backup for %OPTIONALDB%.%OPTIONALTABLE%.
-    endlocal
-    exit /b 1
-)
-
+if not exist "%OPTIONALREADY%" goto StageOptionalTableAssemblyFailed
 endlocal
 exit /b 0
 
-:DumpOptionalTableAssemblyFailed
+:StageOptionalTableAssemblyFailed
 if exist "%OPTIONALTEMP%" del /Q "%OPTIONALTEMP%"
 if exist "%OPTIONALREADY%" del /Q "%OPTIONALREADY%"
 echo ERROR: Could not assemble backup for %OPTIONALDB%.%OPTIONALTABLE%.
+endlocal
+exit /b 1
+
+:CleanupOptionalGroupArtifacts
+setlocal EnableExtensions EnableDelayedExpansion
+set "OPTIONALDIR=%~1"
+set "OPTIONALFAILED=0"
+for %%T in ("%~2" "%~3" "%~4") do if not "%%~T" == "" (
+    for %%S in (exists.tmp dump.tmp sql.new present.tmp absent.tmp) do (
+        if exist "!OPTIONALDIR!\%%~T.%%S" del /Q "!OPTIONALDIR!\%%~T.%%S"
+        if exist "!OPTIONALDIR!\%%~T.%%S" set "OPTIONALFAILED=1"
+    )
+)
+if "!OPTIONALFAILED!" == "1" (
+    endlocal
+    exit /b 1
+)
+endlocal
+exit /b 0
+
+:DumpOptionalGroupRetainEmpty
+echo WARNING: No optional tables exist in %OPTIONALDB%; preserving prior group backups.
+call :CleanupOptionalGroupArtifacts "!OPTIONALDIR!" "%~5" "%~6" "%~7"
+if errorlevel 1 goto DumpOptionalGroupFailed
+endlocal
+exit /b 0
+
+:DumpOptionalGroupFailed
+call :CleanupOptionalGroupArtifacts "!OPTIONALDIR!" "%~5" "%~6" "%~7"
+echo ERROR: Could not back up optional table group in %OPTIONALDB%.
 endlocal
 exit /b 1
 

--- a/Tools/backupDB.cmd
+++ b/Tools/backupDB.cmd
@@ -2198,6 +2198,9 @@ set "OPTIONALRETAINEMPTY=%~4"
 set "OPTIONALPRESENT=0"
 set "OPTIONALFAILED=0"
 
+call :RecoverOptionalGroupAtEntry "!OPTIONALDIR!" "%~5" "%~6" "%~7"
+if errorlevel 1 goto DumpOptionalGroupEntryRecoveryRefused
+
 for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
     for %%S in (exists.tmp dump.tmp sql.new present.tmp absent.tmp) do (
         if exist "!OPTIONALDIR!\%%~T.%%S" del /Q "!OPTIONALDIR!\%%~T.%%S"
@@ -2229,7 +2232,11 @@ for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
 )
 if "!OPTIONALFAILED!" == "1" goto DumpOptionalGroupFailed
 
-rem Phase 3: publish every complete staged member.
+rem Phase 3: snapshot every destination before changing any published output.
+call :SnapshotOptionalGroup "!OPTIONALDIR!" "%~5" "%~6" "%~7"
+if errorlevel 1 goto DumpOptionalGroupFailed
+
+rem Phase 4: publish every complete staged member.
 set "OPTIONALFAILED=0"
 for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
     set "OPTIONALREADY=!OPTIONALDIR!\%%~T.sql.new"
@@ -2241,7 +2248,7 @@ for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
 )
 if "!OPTIONALFAILED!" == "1" goto DumpOptionalGroupFailed
 
-rem Phase 4: only now remove outputs proven absent.
+rem Phase 5: only now remove outputs proven absent.
 set "OPTIONALFAILED=0"
 for %%T in ("%~5" "%~6" "%~7") do if not "%%~T" == "" (
     if exist "!OPTIONALDIR!\%%~T.absent.tmp" (
@@ -2254,6 +2261,10 @@ if "!OPTIONALFAILED!" == "1" goto DumpOptionalGroupFailed
 
 call :CleanupOptionalGroupArtifacts "!OPTIONALDIR!" "%~5" "%~6" "%~7"
 if errorlevel 1 goto DumpOptionalGroupFailed
+
+rem The complete new group is published; retire recovery state last.
+call :CleanupOptionalGroupRecoveryArtifacts "!OPTIONALDIR!" "%~5" "%~6" "%~7"
+if errorlevel 1 goto DumpOptionalGroupRecoveryCleanupFailed
 endlocal
 exit /b 0
 
@@ -2426,10 +2437,150 @@ endlocal
 exit /b 0
 
 :DumpOptionalGroupFailed
+call :RestoreOptionalGroup "!OPTIONALDIR!" "%~5" "%~6" "%~7"
+if errorlevel 1 goto DumpOptionalGroupRollbackFailed
 call :CleanupOptionalGroupArtifacts "!OPTIONALDIR!" "%~5" "%~6" "%~7"
 echo ERROR: Could not back up optional table group in %OPTIONALDB%.
 endlocal
 exit /b 1
+
+:DumpOptionalGroupRollbackFailed
+call :CleanupOptionalGroupArtifacts "!OPTIONALDIR!" "%~5" "%~6" "%~7"
+echo ERROR: Could not restore the optional table group in %OPTIONALDB%; recovery artifacts remain in !OPTIONALDIR!.
+endlocal
+exit /b 1
+
+:DumpOptionalGroupEntryRecoveryRefused
+echo ERROR: Refusing optional table backup for %OPTIONALDB%; preserving published outputs and recovery artifacts in !OPTIONALDIR!.
+endlocal
+exit /b 1
+
+:DumpOptionalGroupRecoveryCleanupFailed
+echo ERROR: Published optional table group, but could not retire all recovery artifacts in %OPTIONALDB%.
+endlocal
+exit /b 1
+
+:CleanupOptionalGroupRecoveryArtifacts
+setlocal EnableExtensions EnableDelayedExpansion
+set "OPTIONALDIR=%~1"
+set "OPTIONALFAILED=0"
+for %%T in ("%~2" "%~3" "%~4") do if not "%%~T" == "" (
+    for %%S in (sql.rollback.tmp sql.no-prior.tmp) do (
+        if exist "!OPTIONALDIR!\%%~T.%%S" del /Q "!OPTIONALDIR!\%%~T.%%S"
+        if exist "!OPTIONALDIR!\%%~T.%%S" set "OPTIONALFAILED=1"
+    )
+)
+if "!OPTIONALFAILED!" == "1" (
+    endlocal
+    exit /b 1
+)
+endlocal
+exit /b 0
+
+:RecoverOptionalGroupAtEntry
+setlocal EnableExtensions EnableDelayedExpansion
+set "OPTIONALDIR=%~1"
+set "OPTIONALRECOVERYANY=0"
+set "OPTIONALRECOVERYCOMPLETE=1"
+for %%T in ("%~2" "%~3" "%~4") do if not "%%~T" == "" (
+    set "OPTIONALRECOVERYCOUNT=0"
+    if exist "!OPTIONALDIR!\%%~T.sql.rollback.tmp" (
+        set /A OPTIONALRECOVERYCOUNT+=1
+        set "OPTIONALRECOVERYANY=1"
+    )
+    if exist "!OPTIONALDIR!\%%~T.sql.no-prior.tmp" (
+        set /A OPTIONALRECOVERYCOUNT+=1
+        set "OPTIONALRECOVERYANY=1"
+    )
+    if !OPTIONALRECOVERYCOUNT! GTR 1 set "OPTIONALRECOVERYCOMPLETE=0"
+)
+if "!OPTIONALRECOVERYANY!" == "0" (
+    endlocal
+    exit /b 0
+)
+for %%T in ("%~2" "%~3" "%~4") do if not "%%~T" == "" (
+    set "OPTIONALRECOVERYCOUNT=0"
+    if exist "!OPTIONALDIR!\%%~T.sql.rollback.tmp" set /A OPTIONALRECOVERYCOUNT+=1
+    if exist "!OPTIONALDIR!\%%~T.sql.no-prior.tmp" set /A OPTIONALRECOVERYCOUNT+=1
+    if not "!OPTIONALRECOVERYCOUNT!" == "1" set "OPTIONALRECOVERYCOMPLETE=0"
+)
+if "!OPTIONALRECOVERYCOMPLETE!" == "0" (
+    echo ERROR: Incomplete optional-group recovery state in %OPTIONALDIR%; preserving artifacts.
+    endlocal
+    exit /b 1
+)
+call :RestoreOptionalGroup "!OPTIONALDIR!" "%~2" "%~3" "%~4"
+if errorlevel 1 (
+    endlocal
+    exit /b 1
+)
+endlocal
+exit /b 0
+
+:SnapshotOptionalGroup
+setlocal EnableExtensions EnableDelayedExpansion
+set "OPTIONALDIR=%~1"
+set "OPTIONALFAILED=0"
+for %%T in ("%~2" "%~3" "%~4") do if not "%%~T" == "" (
+    set "OPTIONALOUTPUT=!OPTIONALDIR!\%%~T.sql"
+    set "OPTIONALROLLBACK=!OPTIONALDIR!\%%~T.sql.rollback.tmp"
+    set "OPTIONALNOPRIOR=!OPTIONALDIR!\%%~T.sql.no-prior.tmp"
+    if "!OPTIONALFAILED!" == "0" (
+        if exist "!OPTIONALROLLBACK!" set "OPTIONALFAILED=1"
+        if exist "!OPTIONALNOPRIOR!" set "OPTIONALFAILED=1"
+    )
+    if "!OPTIONALFAILED!" == "0" if exist "!OPTIONALOUTPUT!" (
+        move /Y "!OPTIONALOUTPUT!" "!OPTIONALROLLBACK!" >nul
+        if errorlevel 1 set "OPTIONALFAILED=1"
+        if exist "!OPTIONALOUTPUT!" set "OPTIONALFAILED=1"
+        if not exist "!OPTIONALROLLBACK!" set "OPTIONALFAILED=1"
+    )
+    if "!OPTIONALFAILED!" == "0" if not exist "!OPTIONALROLLBACK!" (
+        type nul > "!OPTIONALNOPRIOR!"
+        if not exist "!OPTIONALNOPRIOR!" set "OPTIONALFAILED=1"
+    )
+)
+if "!OPTIONALFAILED!" == "1" (
+    endlocal
+    exit /b 1
+)
+endlocal
+exit /b 0
+
+:RestoreOptionalGroup
+setlocal EnableExtensions EnableDelayedExpansion
+set "OPTIONALDIR=%~1"
+set "OPTIONALFAILED=0"
+for %%T in ("%~2" "%~3" "%~4") do if not "%%~T" == "" (
+    set "OPTIONALOUTPUT=!OPTIONALDIR!\%%~T.sql"
+    set "OPTIONALROLLBACK=!OPTIONALDIR!\%%~T.sql.rollback.tmp"
+    set "OPTIONALNOPRIOR=!OPTIONALDIR!\%%~T.sql.no-prior.tmp"
+    set "OPTIONALRECOVERYCOUNT=0"
+    if exist "!OPTIONALROLLBACK!" set /A OPTIONALRECOVERYCOUNT+=1
+    if exist "!OPTIONALNOPRIOR!" set /A OPTIONALRECOVERYCOUNT+=1
+    if !OPTIONALRECOVERYCOUNT! GTR 1 set "OPTIONALFAILED=1"
+    if "!OPTIONALRECOVERYCOUNT!" == "1" if exist "!OPTIONALROLLBACK!" (
+        move /Y "!OPTIONALROLLBACK!" "!OPTIONALOUTPUT!" >nul
+        if errorlevel 1 set "OPTIONALFAILED=1"
+        if exist "!OPTIONALROLLBACK!" set "OPTIONALFAILED=1"
+        if not exist "!OPTIONALOUTPUT!" set "OPTIONALFAILED=1"
+    )
+    if "!OPTIONALRECOVERYCOUNT!" == "1" if exist "!OPTIONALNOPRIOR!" (
+        if exist "!OPTIONALOUTPUT!" del /Q "!OPTIONALOUTPUT!"
+        if exist "!OPTIONALOUTPUT!" (
+            set "OPTIONALFAILED=1"
+        ) else (
+            del /Q "!OPTIONALNOPRIOR!"
+            if exist "!OPTIONALNOPRIOR!" set "OPTIONALFAILED=1"
+        )
+    )
+)
+if "!OPTIONALFAILED!" == "1" (
+    endlocal
+    exit /b 1
+)
+endlocal
+exit /b 0
 
 
 

--- a/Tools/backupDB.cmd
+++ b/Tools/backupDB.cmd
@@ -1500,7 +1500,7 @@ if %loadworldDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_worlddb\%TAB
 if %loadworldDB% == NO echo -- ---------------------------------------- >>  _full_worlddb\%TABLENAME%.sql
 mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %wdb% %TABLENAME% >>  _full_worlddb\%TABLENAME%.sql
 
-SET TABLENAME=warden
+SET TABLENAME=warden_checks
 echo             %TABLENAME%
 if %loadworldDB% == NO echo -- ---------------------------------------- >  _full_worlddb\%TABLENAME%.sql
 if %loadworldDB% == NO echo -- --        CLEAR DOWN THE TABLE        -- >>  _full_worlddb\%TABLENAME%.sql
@@ -2100,15 +2100,6 @@ if %loadcharDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_chardb\%TABLE
 if %loadcharDB% == NO echo -- ---------------------------------------- >>  _full_chardb\%TABLENAME%.sql
 mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %cdb% %TABLENAME% >>  _full_chardb\%TABLENAME%.sql
 
-SET TABLENAME=warden_action
-echo             %TABLENAME%
-if %loadcharDB% == NO echo -- ---------------------------------------- >  _full_chardb\%TABLENAME%.sql
-if %loadcharDB% == NO echo -- --        CLEAR DOWN THE TABLE        -- >>  _full_chardb\%TABLENAME%.sql
-if %loadcharDB% == NO echo -- ---------------------------------------- >>  _full_chardb\%TABLENAME%.sql
-if %loadcharDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_chardb\%TABLENAME%.sql
-if %loadcharDB% == NO echo -- ---------------------------------------- >>  _full_chardb\%TABLENAME%.sql
-mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %cdb% %TABLENAME% >>  _full_chardb\%TABLENAME%.sql
-
 SET TABLENAME=world
 echo             %TABLENAME%
 if %loadcharDB% == NO echo -- ---------------------------------------- >  _full_chardb\%TABLENAME%.sql
@@ -2195,7 +2186,16 @@ if %loadrealmDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_realmdb\%TAB
 if %loadrealmDB% == NO echo -- ---------------------------------------- >>  _full_realmdb\%TABLENAME%.sql
 mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %rdb% %TABLENAME% >>  _full_realmdb\%TABLENAME%.sql
 
-SET TABLENAME=warden_log
+SET TABLENAME=warden_incident
+echo             %TABLENAME%
+if %loadrealmDB% == NO echo -- ---------------------------------------- >  _full_realmdb\%TABLENAME%.sql
+if %loadrealmDB% == NO echo -- --        CLEAR DOWN THE TABLE        -- >>  _full_realmdb\%TABLENAME%.sql
+if %loadrealmDB% == NO echo -- ---------------------------------------- >>  _full_realmdb\%TABLENAME%.sql
+if %loadrealmDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_realmdb\%TABLENAME%.sql
+if %loadrealmDB% == NO echo -- ---------------------------------------- >>  _full_realmdb\%TABLENAME%.sql
+mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %rdb% %TABLENAME% >>  _full_realmdb\%TABLENAME%.sql
+
+SET TABLENAME=warden_audit
 echo             %TABLENAME%
 if %loadrealmDB% == NO echo -- ---------------------------------------- >  _full_realmdb\%TABLENAME%.sql
 if %loadrealmDB% == NO echo -- --        CLEAR DOWN THE TABLE        -- >>  _full_realmdb\%TABLENAME%.sql

--- a/Tools/backupDB.cmd
+++ b/Tools/backupDB.cmd
@@ -1,4 +1,5 @@
 @ECHO OFF
+set "BACKUPRESULT=0"
 rem -- set the main parameters
 set createcharDB=YES
 set createworldDB=YES
@@ -2229,6 +2230,11 @@ if not "%OPTIONALFOUND%" == "0" if not "%OPTIONALFOUND%" == "1" (
 
 if "%OPTIONALFOUND%" == "0" (
     if exist "%OPTIONALOUTPUT%" del /Q "%OPTIONALOUTPUT%"
+    if exist "%OPTIONALOUTPUT%" (
+        echo ERROR: Could not remove stale backup for %OPTIONALDB%.%OPTIONALTABLE%.
+        endlocal
+        exit /b 1
+    )
     echo Skipping absent optional table %OPTIONALDB%.%OPTIONALTABLE%.
     endlocal
     exit /b 0
@@ -2247,15 +2253,23 @@ if errorlevel 1 (
 )
 
 if /I "%OPTIONALSTRUCTURE%" == "NO" (
-    echo -- ---------------------------------------- > "%OPTIONALREADY%"
-    echo -- --        CLEAR DOWN THE TABLE        -- >> "%OPTIONALREADY%"
-    echo -- ---------------------------------------- >> "%OPTIONALREADY%"
-    echo TRUNCATE TABLE `%OPTIONALTABLE%`; >> "%OPTIONALREADY%"
-    echo -- ---------------------------------------- >> "%OPTIONALREADY%"
-    type "%OPTIONALTEMP%" >> "%OPTIONALREADY%"
+    %ComSpec% /D /C echo -- ---------------------------------------- ^> "%OPTIONALREADY%"
+    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    %ComSpec% /D /C echo -- --        CLEAR DOWN THE TABLE        -- ^>^> "%OPTIONALREADY%"
+    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    %ComSpec% /D /C echo -- ---------------------------------------- ^>^> "%OPTIONALREADY%"
+    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    %ComSpec% /D /C echo TRUNCATE TABLE `%OPTIONALTABLE%`; ^>^> "%OPTIONALREADY%"
+    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    %ComSpec% /D /C echo -- ---------------------------------------- ^>^> "%OPTIONALREADY%"
+    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
+    %ComSpec% /D /C type "%OPTIONALTEMP%" ^>^> "%OPTIONALREADY%"
+    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
     del /Q "%OPTIONALTEMP%"
+    if exist "%OPTIONALTEMP%" goto DumpOptionalTableAssemblyFailed
 ) else (
     move /Y "%OPTIONALTEMP%" "%OPTIONALREADY%" >nul
+    if errorlevel 1 goto DumpOptionalTableAssemblyFailed
 )
 
 move /Y "%OPTIONALREADY%" "%OPTIONALOUTPUT%" >nul
@@ -2268,9 +2282,17 @@ if errorlevel 1 (
 endlocal
 exit /b 0
 
+:DumpOptionalTableAssemblyFailed
+if exist "%OPTIONALTEMP%" del /Q "%OPTIONALTEMP%"
+if exist "%OPTIONALREADY%" del /Q "%OPTIONALREADY%"
+echo ERROR: Could not assemble backup for %OPTIONALDB%.%OPTIONALTABLE%.
+endlocal
+exit /b 1
+
 
 
 :patherror
+set "BACKUPRESULT=1"
 echo.
 echo _______________________________________________________________________________
 echo %colWhiteDarkRed%^|                                                                             ^|
@@ -2282,6 +2304,7 @@ echo.
 goto finish:
 
 :error
+set "BACKUPRESULT=1"
 echo.
 echo _______________________________________________________________________________
 echo %colWhiteDarkRed%^|                                                                             ^|
@@ -2310,3 +2333,4 @@ echo Done :)
 echo.
 :finish
 pause
+exit /b %BACKUPRESULT%

--- a/Tools/backupDB.cmd
+++ b/Tools/backupDB.cmd
@@ -1500,14 +1500,10 @@ if %loadworldDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_worlddb\%TAB
 if %loadworldDB% == NO echo -- ---------------------------------------- >>  _full_worlddb\%TABLENAME%.sql
 mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %wdb% %TABLENAME% >>  _full_worlddb\%TABLENAME%.sql
 
-SET TABLENAME=warden_checks
-echo             %TABLENAME%
-if %loadworldDB% == NO echo -- ---------------------------------------- >  _full_worlddb\%TABLENAME%.sql
-if %loadworldDB% == NO echo -- --        CLEAR DOWN THE TABLE        -- >>  _full_worlddb\%TABLENAME%.sql
-if %loadworldDB% == NO echo -- ---------------------------------------- >>  _full_worlddb\%TABLENAME%.sql
-if %loadworldDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_worlddb\%TABLENAME%.sql
-if %loadworldDB% == NO echo -- ---------------------------------------- >>  _full_worlddb\%TABLENAME%.sql
-mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %wdb% %TABLENAME% >>  _full_worlddb\%TABLENAME%.sql
+call :DumpOptionalTable "%wdb%" "_full_worlddb" "%loadworldDB%" "warden"
+if errorlevel 1 goto error
+call :DumpOptionalTable "%wdb%" "_full_worlddb" "%loadworldDB%" "warden_checks"
+if errorlevel 1 goto error
 
 goto CharDB:
 
@@ -2108,6 +2104,9 @@ if %loadcharDB% == NO echo -- ---------------------------------------- >>  _full
 if %loadcharDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_chardb\%TABLENAME%.sql
 if %loadcharDB% == NO echo -- ---------------------------------------- >>  _full_chardb\%TABLENAME%.sql
 mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %cdb% %TABLENAME% >>  _full_chardb\%TABLENAME%.sql
+
+call :DumpOptionalTable "%cdb%" "_full_chardb" "%loadcharDB%" "warden_action"
+if errorlevel 1 goto error
 goto RealmDB:
 
 :RealmDB1
@@ -2186,25 +2185,88 @@ if %loadrealmDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_realmdb\%TAB
 if %loadrealmDB% == NO echo -- ---------------------------------------- >>  _full_realmdb\%TABLENAME%.sql
 mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %rdb% %TABLENAME% >>  _full_realmdb\%TABLENAME%.sql
 
-SET TABLENAME=warden_incident
-echo             %TABLENAME%
-if %loadrealmDB% == NO echo -- ---------------------------------------- >  _full_realmdb\%TABLENAME%.sql
-if %loadrealmDB% == NO echo -- --        CLEAR DOWN THE TABLE        -- >>  _full_realmdb\%TABLENAME%.sql
-if %loadrealmDB% == NO echo -- ---------------------------------------- >>  _full_realmdb\%TABLENAME%.sql
-if %loadrealmDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_realmdb\%TABLENAME%.sql
-if %loadrealmDB% == NO echo -- ---------------------------------------- >>  _full_realmdb\%TABLENAME%.sql
-mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %rdb% %TABLENAME% >>  _full_realmdb\%TABLENAME%.sql
-
-SET TABLENAME=warden_audit
-echo             %TABLENAME%
-if %loadrealmDB% == NO echo -- ---------------------------------------- >  _full_realmdb\%TABLENAME%.sql
-if %loadrealmDB% == NO echo -- --        CLEAR DOWN THE TABLE        -- >>  _full_realmdb\%TABLENAME%.sql
-if %loadrealmDB% == NO echo -- ---------------------------------------- >>  _full_realmdb\%TABLENAME%.sql
-if %loadrealmDB% == NO echo TRUNCATE TABLE `%TABLENAME%`; >>  _full_realmdb\%TABLENAME%.sql
-if %loadrealmDB% == NO echo -- ---------------------------------------- >>  _full_realmdb\%TABLENAME%.sql
-mysqldump -Q -c -e -q %extraparams% -u%user% -p%pass% --port=%port% -h %svr% %rdb% %TABLENAME% >>  _full_realmdb\%TABLENAME%.sql
+call :DumpOptionalTable "%rdb%" "_full_realmdb" "%loadrealmDB%" "warden_log"
+if errorlevel 1 goto error
+call :DumpOptionalTable "%rdb%" "_full_realmdb" "%loadrealmDB%" "warden_incident"
+if errorlevel 1 goto error
+call :DumpOptionalTable "%rdb%" "_full_realmdb" "%loadrealmDB%" "warden_audit"
+if errorlevel 1 goto error
 
 goto done:
+
+:DumpOptionalTable
+setlocal
+set "OPTIONALDB=%~1"
+set "OPTIONALDIR=%~2"
+set "OPTIONALSTRUCTURE=%~3"
+set "OPTIONALTABLE=%~4"
+set "OPTIONALOUTPUT=%OPTIONALDIR%\%OPTIONALTABLE%.sql"
+set "OPTIONALPROBE=%OPTIONALDIR%\%OPTIONALTABLE%.exists.tmp"
+set "OPTIONALTEMP=%OPTIONALDIR%\%OPTIONALTABLE%.dump.tmp"
+set "OPTIONALREADY=%OPTIONALDIR%\%OPTIONALTABLE%.sql.new"
+
+if exist "%OPTIONALPROBE%" del /Q "%OPTIONALPROBE%"
+if exist "%OPTIONALTEMP%" del /Q "%OPTIONALTEMP%"
+if exist "%OPTIONALREADY%" del /Q "%OPTIONALREADY%"
+
+"%mysql%mysql.exe" --batch --skip-column-names -u%user% -p%pass% --port=%port% -h %svr% -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '%OPTIONALDB%' AND table_name = '%OPTIONALTABLE%';" > "%OPTIONALPROBE%" 2>nul
+if errorlevel 1 (
+    if exist "%OPTIONALPROBE%" del /Q "%OPTIONALPROBE%"
+    echo ERROR: Could not inspect %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 1
+)
+
+set "OPTIONALFOUND="
+set /p OPTIONALFOUND=<"%OPTIONALPROBE%"
+del /Q "%OPTIONALPROBE%"
+
+if not "%OPTIONALFOUND%" == "0" if not "%OPTIONALFOUND%" == "1" (
+    echo ERROR: Invalid table probe result for %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 1
+)
+
+if "%OPTIONALFOUND%" == "0" (
+    if exist "%OPTIONALOUTPUT%" del /Q "%OPTIONALOUTPUT%"
+    echo Skipping absent optional table %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 0
+)
+
+set "OPTIONALPARAMS="
+if /I "%OPTIONALSTRUCTURE%" == "NO" set "OPTIONALPARAMS=--add-drop-table=false --no-create-info"
+
+echo             %OPTIONALTABLE%
+"%mysql%mysqldump.exe" -Q -c -e -q %OPTIONALPARAMS% -u%user% -p%pass% --port=%port% -h %svr% %OPTIONALDB% %OPTIONALTABLE% > "%OPTIONALTEMP%"
+if errorlevel 1 (
+    if exist "%OPTIONALTEMP%" del /Q "%OPTIONALTEMP%"
+    echo ERROR: Could not dump %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 1
+)
+
+if /I "%OPTIONALSTRUCTURE%" == "NO" (
+    echo -- ---------------------------------------- > "%OPTIONALREADY%"
+    echo -- --        CLEAR DOWN THE TABLE        -- >> "%OPTIONALREADY%"
+    echo -- ---------------------------------------- >> "%OPTIONALREADY%"
+    echo TRUNCATE TABLE `%OPTIONALTABLE%`; >> "%OPTIONALREADY%"
+    echo -- ---------------------------------------- >> "%OPTIONALREADY%"
+    type "%OPTIONALTEMP%" >> "%OPTIONALREADY%"
+    del /Q "%OPTIONALTEMP%"
+) else (
+    move /Y "%OPTIONALTEMP%" "%OPTIONALREADY%" >nul
+)
+
+move /Y "%OPTIONALREADY%" "%OPTIONALOUTPUT%" >nul
+if errorlevel 1 (
+    echo ERROR: Could not publish backup for %OPTIONALDB%.%OPTIONALTABLE%.
+    endlocal
+    exit /b 1
+)
+
+endlocal
+exit /b 0
 
 
 

--- a/Tools/dump_tables.sh
+++ b/Tools/dump_tables.sh
@@ -32,8 +32,8 @@ esac
 done
 
 if [ -z "${WARDEN_TABLES}" ]; then
-echo "Neither warden nor warden_checks exists in ${DB}; refusing an incomplete dump." >&2
-return 1
+echo "Neither warden nor warden_checks exists in ${DB}; retaining prior Warden dumps and continuing." >&2
+return 0
 fi
 
 for WARDEN_TABLE in ${WARDEN_TABLES}; do

--- a/Tools/dump_tables.sh
+++ b/Tools/dump_tables.sh
@@ -16,6 +16,20 @@ do_dump_zero() {
 
 mkdir -p ${DUMPDIR}
 
+WARDEN_TABLES=
+for WARDEN_TABLE in warden warden_checks; do
+if mysqldump -Q -q -u"${USERNAME}" -p"${PASSWORD}" --no-data "${DB}" "${WARDEN_TABLE}" >/dev/null 2>&1; then
+WARDEN_TABLES="${WARDEN_TABLES} ${WARDEN_TABLE}"
+fi
+done
+
+if [ -z "${WARDEN_TABLES}" ]; then
+echo "Neither warden nor warden_checks exists in ${DB}; refusing an incomplete dump." >&2
+return 1
+fi
+
+rm -f "${DUMPDIR}/warden.sql" "${DUMPDIR}/warden_checks.sql"
+
 for TABLE in \
 `areatrigger_involvedrelation` \
 `areatrigger_tavern` \
@@ -139,7 +153,7 @@ for TABLE in \
 `spell_target_position` \
 `spell_threat` \
 `transports` \
-`warden_checks` \
+${WARDEN_TABLES} \
 ; do
 
 echo "Dumping ${i}/123 ${TABLE}..."

--- a/Tools/dump_tables.sh
+++ b/Tools/dump_tables.sh
@@ -10,17 +10,25 @@ DDUMPDIR=./mangos
 ###################################################################################
 
 i=1
-
-
-do_dump_zero() {
-
-mkdir -p ${DUMPDIR}
+dump_warden_tables() {
 
 WARDEN_TABLES=
 for WARDEN_TABLE in warden warden_checks; do
-if mysqldump -Q -q -u"${USERNAME}" -p"${PASSWORD}" --no-data "${DB}" "${WARDEN_TABLE}" >/dev/null 2>&1; then
-WARDEN_TABLES="${WARDEN_TABLES} ${WARDEN_TABLE}"
+if ! WARDEN_FOUND=$(mysql --batch --skip-column-names -u"${USERNAME}" -p"${PASSWORD}" "${DB}" -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '${WARDEN_TABLE}';" 2>/dev/null); then
+echo "Could not inspect ${DB}.${WARDEN_TABLE}; retaining prior backups." >&2
+return 1
 fi
+case "${WARDEN_FOUND}" in
+0)
+;;
+1)
+WARDEN_TABLES="${WARDEN_TABLES} ${WARDEN_TABLE}"
+;;
+*)
+echo "Invalid table probe result for ${DB}.${WARDEN_TABLE}." >&2
+return 1
+;;
+esac
 done
 
 if [ -z "${WARDEN_TABLES}" ]; then
@@ -28,132 +36,174 @@ echo "Neither warden nor warden_checks exists in ${DB}; refusing an incomplete d
 return 1
 fi
 
-rm -f "${DUMPDIR}/warden.sql" "${DUMPDIR}/warden_checks.sql"
+for WARDEN_TABLE in ${WARDEN_TABLES}; do
+WARDEN_READY="${DUMPDIR}/${WARDEN_TABLE}.sql.new"
+if ! rm -f "${WARDEN_READY}"; then
+echo "Could not clear staged ${WARDEN_TABLE} dump." >&2
+return 1
+fi
+if ! mysqldump -Q -c -e -q -u"${USERNAME}" -p"${PASSWORD}" "${DB}" "${WARDEN_TABLE}" > "${WARDEN_READY}"; then
+rm -f "${DUMPDIR}/warden.sql.new" "${DUMPDIR}/warden_checks.sql.new"
+echo "Could not dump ${DB}.${WARDEN_TABLE}; retaining prior backups." >&2
+return 1
+fi
+done
+
+for WARDEN_TABLE in ${WARDEN_TABLES}; do
+WARDEN_READY="${DUMPDIR}/${WARDEN_TABLE}.sql.new"
+if ! mv -f "${WARDEN_READY}" "${DUMPDIR}/${WARDEN_TABLE}.sql"; then
+echo "Could not publish ${DB}.${WARDEN_TABLE}; retaining remaining prior backups." >&2
+return 1
+fi
+done
+
+for WARDEN_TABLE in warden warden_checks; do
+case " ${WARDEN_TABLES} " in
+*" ${WARDEN_TABLE} "*)
+;;
+*)
+if ! rm -f "${DUMPDIR}/${WARDEN_TABLE}.sql"; then
+echo "Could not remove stale ${WARDEN_TABLE} dump." >&2
+return 1
+fi
+;;
+esac
+done
+}
+
+
+
+do_dump_zero() {
+
+mkdir -p ${DUMPDIR}
+
+if ! dump_warden_tables; then
+return 1
+fi
 
 for TABLE in \
-`areatrigger_involvedrelation` \
-`areatrigger_tavern` \
-`areatrigger_teleport` \
-`battleground_events` \
-`battleground_template` \
-`battlemaster_entry` \
-`command` \
-`conditions` \
-`creature` \
-`creature_addon` \
-`creature_ai_scripts` \
-`creature_ai_summons` \
-`creature_ai_texts` \
-`creature_battleground` \
-`creature_equip_template` \
-`creature_equip_template_raw` \
-`creature_involvedrelation` \
-`creature_item_template` \
-`creature_linking` \
-`creature_linking_template` \
-`creature_loot_template` \
-`creature_model_info` \
-`creature_movement` \
-`creature_movement_template` \
-`creature_onkill_reputation` \
-`creature_questrelation` \
-`creature_spells` \
-`creature_template` \
-`creature_template_addon` \
-`creature_template_classlevelstats` \
-`creature_template_spells` \
-`custom_texts` \
-`db_script_string` \
-`db_scripts` \
-`db_version` \
-`disables` \
-`disenchant_loot_template` \
-`exploration_basexp` \
-`fishing_loot_template` \
-`game_event` \
-`game_event_creature` \
-`game_event_creature_data` \
-`game_event_gameobject` \
-`game_event_mail` \
-`game_event_quest` \
-`game_graveyard_zone` \
-`game_tele` \
-`game_weather` \
-`gameobject` \
-`gameobject_battleground` \
-`gameobject_involvedrelation` \
-`gameobject_loot_template` \
-`gameobject_questrelation` \
-`gameobject_template` \
-`gossip_menu` \
-`gossip_menu_option` \
-`gossip_texts` \
-`instance_template` \
-`item_enchantment_template` \
-`item_loot_template` \
-`item_required_target` \
-`item_template` \
-`locales_command` \
-`locales_creature` \
-`locales_gameobject` \
-`locales_gossip_menu_option` \
-`locales_item` \
-`locales_npc_text` \
-`locales_page_text` \
-`locales_points_of_interest` \
-`locales_quest` \
-`mail_loot_template` \
-`mangos_string` \
-`npc_text` \
-`npc_trainer` \
-`npc_trainer_template` \
-`npc_vendor` \
-`npc_vendor_template` \
-`page_text` \
-`pet_levelstats` \
-`pet_name_generation` \
-`petcreateinfo_spell` \
-`pickpocketing_loot_template` \
-`player_classlevelstats` \
-`player_levelstats` \
-`player_xp_for_level` \
-`playercreateinfo` \
-`playercreateinfo_action` \
-`playercreateinfo_item` \
-`playercreateinfo_spell` \
-`points_of_interest` \
-`pool_creature` \
-`pool_creature_template` \
-`pool_gameobject` \
-`pool_gameobject_template` \
-`pool_pool` \
-`pool_template` \
-`quest_template` \
-`reference_loot_template` \
-`reputation_reward_rate` \
-`reputation_spillover_template` \
-`reserved_name` \
-`script_binding` \
-`script_texts` \
-`script_waypoint` \
-`skill_fishing_base_level` \
-`skinning_loot_template` \
-`spell_affect` \
-`spell_area` \
-`spell_bonus_data` \
-`spell_chain` \
-`spell_elixir` \
-`spell_facing` \
-`spell_learn_spell` \
-`spell_linked` \
-`spell_pet_auras` \
-`spell_proc_event` \
-`spell_proc_item_enchant` \
-`spell_script_target` \
-`spell_target_position` \
-`spell_threat` \
-`transports` \
-${WARDEN_TABLES} \
+areatrigger_involvedrelation \
+areatrigger_tavern \
+areatrigger_teleport \
+battleground_events \
+battleground_template \
+battlemaster_entry \
+command \
+conditions \
+creature \
+creature_addon \
+creature_ai_scripts \
+creature_ai_summons \
+creature_ai_texts \
+creature_battleground \
+creature_equip_template \
+creature_equip_template_raw \
+creature_involvedrelation \
+creature_item_template \
+creature_linking \
+creature_linking_template \
+creature_loot_template \
+creature_model_info \
+creature_movement \
+creature_movement_template \
+creature_onkill_reputation \
+creature_questrelation \
+creature_spells \
+creature_template \
+creature_template_addon \
+creature_template_classlevelstats \
+creature_template_spells \
+custom_texts \
+db_script_string \
+db_scripts \
+db_version \
+disables \
+disenchant_loot_template \
+exploration_basexp \
+fishing_loot_template \
+game_event \
+game_event_creature \
+game_event_creature_data \
+game_event_gameobject \
+game_event_mail \
+game_event_quest \
+game_graveyard_zone \
+game_tele \
+game_weather \
+gameobject \
+gameobject_battleground \
+gameobject_involvedrelation \
+gameobject_loot_template \
+gameobject_questrelation \
+gameobject_template \
+gossip_menu \
+gossip_menu_option \
+gossip_texts \
+instance_template \
+item_enchantment_template \
+item_loot_template \
+item_required_target \
+item_template \
+locales_command \
+locales_creature \
+locales_gameobject \
+locales_gossip_menu_option \
+locales_item \
+locales_npc_text \
+locales_page_text \
+locales_points_of_interest \
+locales_quest \
+mail_loot_template \
+mangos_string \
+npc_text \
+npc_trainer \
+npc_trainer_template \
+npc_vendor \
+npc_vendor_template \
+page_text \
+pet_levelstats \
+pet_name_generation \
+petcreateinfo_spell \
+pickpocketing_loot_template \
+player_classlevelstats \
+player_levelstats \
+player_xp_for_level \
+playercreateinfo \
+playercreateinfo_action \
+playercreateinfo_item \
+playercreateinfo_spell \
+points_of_interest \
+pool_creature \
+pool_creature_template \
+pool_gameobject \
+pool_gameobject_template \
+pool_pool \
+pool_template \
+quest_template \
+reference_loot_template \
+reputation_reward_rate \
+reputation_spillover_template \
+reserved_name \
+script_binding \
+script_texts \
+script_waypoint \
+skill_fishing_base_level \
+skinning_loot_template \
+spell_affect \
+spell_area \
+spell_bonus_data \
+spell_chain \
+spell_elixir \
+spell_facing \
+spell_learn_spell \
+spell_linked \
+spell_pet_auras \
+spell_proc_event \
+spell_proc_item_enchant \
+spell_script_target \
+spell_target_position \
+spell_threat \
+transports \
 ; do
 
 echo "Dumping ${i}/123 ${TABLE}..."
@@ -177,11 +227,11 @@ echo "--
 --
 " > ${DUMPDIR}/${TABLE}.sql
 
-mysqldump -Q -c -e -q -u${USERNAME} -p${PASSWORD} $DB ${TABLE}` \
-  | sed "s/VALUES /VALUES\n/g"` \
-  | sed "s/),(/),\n(/g"` \
-  | grep -v "Dump completed"` \
-  | sed -e "1d;2d;3d;4d;5d;6d"` \
+mysqldump -Q -c -e -q -u${USERNAME} -p${PASSWORD} $DB ${TABLE} \
+  | sed "s/VALUES /VALUES\n/g" \
+  | sed "s/),(/),\n(/g" \
+  | grep -v "Dump completed" \
+  | sed -e "1d;2d;3d;4d;5d;6d" \
 >> ${DUMPDIR}/${TABLE}.sql
 
 let i=i+1

--- a/Tools/dump_tables.sh
+++ b/Tools/dump_tables.sh
@@ -139,7 +139,7 @@ for TABLE in \
 `spell_target_position` \
 `spell_threat` \
 `transports` \
-`warden` \
+`warden_checks` \
 ; do
 
 echo "Dumping ${i}/123 ${TABLE}..."

--- a/Tools/dump_tables.sh
+++ b/Tools/dump_tables.sh
@@ -10,7 +10,55 @@ DDUMPDIR=./mangos
 ###################################################################################
 
 i=1
+restore_warden_group() {
+
+WARDEN_RESTORE_FAILED=0
+for WARDEN_TABLE in warden warden_checks; do
+WARDEN_OUTPUT="${DUMPDIR}/${WARDEN_TABLE}.sql"
+WARDEN_ROLLBACK="${WARDEN_OUTPUT}.rollback.tmp"
+WARDEN_NO_PRIOR="${WARDEN_OUTPUT}.no-prior.tmp"
+if [ -e "${WARDEN_ROLLBACK}" ] && [ -e "${WARDEN_NO_PRIOR}" ]; then
+WARDEN_RESTORE_FAILED=1
+elif [ -e "${WARDEN_ROLLBACK}" ]; then
+if ! mv -f "${WARDEN_ROLLBACK}" "${WARDEN_OUTPUT}" || [ -e "${WARDEN_ROLLBACK}" ] || [ ! -e "${WARDEN_OUTPUT}" ]; then
+WARDEN_RESTORE_FAILED=1
+fi
+elif [ -e "${WARDEN_NO_PRIOR}" ]; then
+if ! rm -f "${WARDEN_OUTPUT}" || [ -e "${WARDEN_OUTPUT}" ]; then
+WARDEN_RESTORE_FAILED=1
+elif ! rm -f "${WARDEN_NO_PRIOR}" || [ -e "${WARDEN_NO_PRIOR}" ]; then
+WARDEN_RESTORE_FAILED=1
+fi
+fi
+done
+[ "${WARDEN_RESTORE_FAILED}" -eq 0 ]
+}
+
 dump_warden_tables() {
+
+WARDEN_RECOVERY_ANY=0
+WARDEN_RECOVERY_COMPLETE=1
+for WARDEN_TABLE in warden warden_checks; do
+WARDEN_RECOVERY_COUNT=0
+[ -e "${DUMPDIR}/${WARDEN_TABLE}.sql.rollback.tmp" ] && WARDEN_RECOVERY_COUNT=$((WARDEN_RECOVERY_COUNT + 1))
+[ -e "${DUMPDIR}/${WARDEN_TABLE}.sql.no-prior.tmp" ] && WARDEN_RECOVERY_COUNT=$((WARDEN_RECOVERY_COUNT + 1))
+if [ "${WARDEN_RECOVERY_COUNT}" -gt 0 ]; then
+WARDEN_RECOVERY_ANY=1
+fi
+if [ "${WARDEN_RECOVERY_COUNT}" -ne 1 ]; then
+WARDEN_RECOVERY_COMPLETE=0
+fi
+done
+if [ "${WARDEN_RECOVERY_ANY}" -eq 1 ]; then
+if [ "${WARDEN_RECOVERY_COMPLETE}" -ne 1 ]; then
+echo "Incomplete Warden recovery state in ${DUMPDIR}; preserving artifacts." >&2
+return 1
+fi
+if ! restore_warden_group; then
+echo "Could not restore stale Warden recovery state; preserving remaining artifacts." >&2
+return 1
+fi
+fi
 
 WARDEN_TABLES=
 for WARDEN_TABLE in warden warden_checks; do
@@ -49,10 +97,37 @@ return 1
 fi
 done
 
+for WARDEN_TABLE in warden warden_checks; do
+WARDEN_OUTPUT="${DUMPDIR}/${WARDEN_TABLE}.sql"
+WARDEN_ROLLBACK="${WARDEN_OUTPUT}.rollback.tmp"
+WARDEN_NO_PRIOR="${WARDEN_OUTPUT}.no-prior.tmp"
+if [ -e "${WARDEN_ROLLBACK}" ] || [ -e "${WARDEN_NO_PRIOR}" ]; then
+echo "Unexpected recovery artifact for ${WARDEN_TABLE}; preserving it." >&2
+restore_warden_group
+rm -f "${DUMPDIR}/warden.sql.new" "${DUMPDIR}/warden_checks.sql.new"
+return 1
+fi
+if [ -e "${WARDEN_OUTPUT}" ]; then
+if ! mv -f "${WARDEN_OUTPUT}" "${WARDEN_ROLLBACK}" || [ -e "${WARDEN_OUTPUT}" ] || [ ! -e "${WARDEN_ROLLBACK}" ]; then
+restore_warden_group
+rm -f "${DUMPDIR}/warden.sql.new" "${DUMPDIR}/warden_checks.sql.new"
+echo "Could not snapshot ${WARDEN_TABLE}; prior group was restored where possible." >&2
+return 1
+fi
+elif ! : > "${WARDEN_NO_PRIOR}" || [ ! -e "${WARDEN_NO_PRIOR}" ]; then
+restore_warden_group
+rm -f "${DUMPDIR}/warden.sql.new" "${DUMPDIR}/warden_checks.sql.new"
+echo "Could not record original absence for ${WARDEN_TABLE}." >&2
+return 1
+fi
+done
+
 for WARDEN_TABLE in ${WARDEN_TABLES}; do
 WARDEN_READY="${DUMPDIR}/${WARDEN_TABLE}.sql.new"
 if ! mv -f "${WARDEN_READY}" "${DUMPDIR}/${WARDEN_TABLE}.sql"; then
-echo "Could not publish ${DB}.${WARDEN_TABLE}; retaining remaining prior backups." >&2
+restore_warden_group
+rm -f "${DUMPDIR}/warden.sql.new" "${DUMPDIR}/warden_checks.sql.new"
+echo "Could not publish ${DB}.${WARDEN_TABLE}; prior group was restored where possible." >&2
 return 1
 fi
 done
@@ -63,12 +138,78 @@ case " ${WARDEN_TABLES} " in
 ;;
 *)
 if ! rm -f "${DUMPDIR}/${WARDEN_TABLE}.sql"; then
+restore_warden_group
+rm -f "${DUMPDIR}/warden.sql.new" "${DUMPDIR}/warden_checks.sql.new"
 echo "Could not remove stale ${WARDEN_TABLE} dump." >&2
 return 1
 fi
 ;;
 esac
 done
+
+WARDEN_RECOVERY_CLEANUP_FAILED=0
+for WARDEN_TABLE in warden warden_checks; do
+for WARDEN_RECOVERY in "${DUMPDIR}/${WARDEN_TABLE}.sql.rollback.tmp" "${DUMPDIR}/${WARDEN_TABLE}.sql.no-prior.tmp"; do
+if ! rm -f "${WARDEN_RECOVERY}" || [ -e "${WARDEN_RECOVERY}" ]; then
+WARDEN_RECOVERY_CLEANUP_FAILED=1
+fi
+done
+done
+if [ "${WARDEN_RECOVERY_CLEANUP_FAILED}" -ne 0 ]; then
+echo "Published Warden group, but could not retire all recovery artifacts." >&2
+return 1
+fi
+}
+
+dump_table() {
+
+TABLE=$1
+TABLE_READY="${DUMPDIR}/${TABLE}.sql.new"
+TABLE_OUTPUT="${DUMPDIR}/${TABLE}.sql"
+if ! rm -f "${TABLE_READY}" || [ -e "${TABLE_READY}" ]; then
+echo "Could not clear staged ${TABLE} dump." >&2
+return 1
+fi
+if ! echo "--
+-- Copyright (C) 2005-2024 MaNGOS <https://getmangos.eu/> <https://github.com/mangoszero>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 2 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program; if not, write to the Free Software
+-- Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+--
+" > "${TABLE_READY}"; then
+rm -f "${TABLE_READY}"
+echo "Could not stage the header for ${TABLE}." >&2
+return 1
+fi
+if ! (
+set -o pipefail
+mysqldump -Q -c -e -q -u"${USERNAME}" -p"${PASSWORD}" "${DB}" "${TABLE}" \
+  | sed "s/VALUES /VALUES\n/g" \
+  | sed "s/),(/),\n(/g" \
+  | sed "/Dump completed/d" \
+  | sed -e "1d;2d;3d;4d;5d;6d"
+) >> "${TABLE_READY}"; then
+rm -f "${TABLE_READY}"
+echo "Could not dump ${DB}.${TABLE}; retaining prior backup." >&2
+return 1
+fi
+if ! mv -f "${TABLE_READY}" "${TABLE_OUTPUT}"; then
+rm -f "${TABLE_READY}"
+echo "Could not publish ${DB}.${TABLE}; retaining prior backup." >&2
+return 1
+fi
+return 0
 }
 
 
@@ -208,31 +349,9 @@ transports \
 
 echo "Dumping ${i}/123 ${TABLE}..."
 
-echo "--
--- Copyright (C) 2005-2024 MaNGOS <https://getmangos.eu/> <https://github.com/mangoszero>
---
--- This program is free software; you can redistribute it and/or modify
--- it under the terms of the GNU General Public License as published by
--- the Free Software Foundation; either version 2 of the License, or
--- (at your option) any later version.
---
--- This program is distributed in the hope that it will be useful,
--- but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
--- GNU General Public License for more details.
---
--- You should have received a copy of the GNU General Public License
--- along with this program; if not, write to the Free Software
--- Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
---
-" > ${DUMPDIR}/${TABLE}.sql
-
-mysqldump -Q -c -e -q -u${USERNAME} -p${PASSWORD} $DB ${TABLE} \
-  | sed "s/VALUES /VALUES\n/g" \
-  | sed "s/),(/),\n(/g" \
-  | grep -v "Dump completed" \
-  | sed -e "1d;2d;3d;4d;5d;6d" \
->> ${DUMPDIR}/${TABLE}.sql
+if ! dump_table "${TABLE}"; then
+return 1
+fi
 
 let i=i+1
 

--- a/Tools/tests/test_warden_transition_scripts.py
+++ b/Tools/tests/test_warden_transition_scripts.py
@@ -29,6 +29,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 INSTALL = (ROOT / "InstallDatabases.sh").read_text(encoding="utf-8")
 BACKUP = (ROOT / "Tools" / "backupDB.cmd").read_text(encoding="utf-8")
+DUMP = (ROOT / "Tools" / "dump_tables.sh").read_text(encoding="utf-8")
 
 
 def shell_function(name: str) -> str:
@@ -130,6 +131,29 @@ class WardenBackupRoutingTests(unittest.TestCase):
         self.assertLess(dump, ready)
         self.assertLess(ready, publish)
         self.assertNotIn('>> "%OPTIONALOUTPUT%"', helper)
+
+
+class WardenUnixDumpRoutingTests(unittest.TestCase):
+    def test_selects_existing_warden_tables_and_cleans_stale_counterparts(self) -> None:
+        candidates = re.search(r"for WARDEN_TABLE in ([^;\n]+); do", DUMP)
+        self.assertIsNotNone(candidates, "Warden table probe loop is missing")
+        self.assertEqual(candidates.group(1).split(), ["warden", "warden_checks"])
+        self.assertRegex(
+            DUMP,
+            r"(?s)for WARDEN_TABLE in warden warden_checks; do.*?"
+            r"mysqldump .*--no-data.*\$\{DB\}.*\$\{WARDEN_TABLE\}",
+        )
+
+        refusal = DUMP.index('if [ -z "${WARDEN_TABLES}" ]; then')
+        cleanup = DUMP.index(
+            'rm -f "${DUMPDIR}/warden.sql" "${DUMPDIR}/warden_checks.sql"'
+        )
+        table_loop = DUMP.index("for TABLE in \\")
+        self.assertLess(refusal, cleanup)
+        self.assertLess(cleanup, table_loop)
+        self.assertIn("Neither warden nor warden_checks exists", DUMP)
+        self.assertIn("${WARDEN_TABLES} \\", DUMP)
+        self.assertNotRegex(DUMP, r"(?m)^`warden(?:_checks)?` \\$")
 
 
 if __name__ == "__main__":

--- a/Tools/tests/test_warden_transition_scripts.py
+++ b/Tools/tests/test_warden_transition_scripts.py
@@ -22,9 +22,11 @@
 # and lore are copyrighted by Blizzard Entertainment, Inc.
 
 from pathlib import Path
+import os
 import re
 import shutil
 import subprocess
+import tempfile
 import unittest
 
 
@@ -54,6 +56,34 @@ def batch_label(name: str, next_label: str) -> str:
     return match.group(1)
 
 
+def batch_helper_region(script: str) -> str:
+    label = re.search(r"(?m)^:DumpOptionalGroup\s*$", script)
+    if not label:
+        raise AssertionError("missing batch label DumpOptionalGroup")
+    start = label.start()
+    end = script.find("\n:patherror", start)
+    if end < 0:
+        raise AssertionError("DumpOptionalGroup helper region is unterminated")
+    return script[start:end].rstrip()
+
+
+def batch_for_blocks(body: str) -> list[str]:
+    lines = body.splitlines()
+    blocks = []
+    for index, line in enumerate(lines):
+        if not re.match(r"(?i)^\s*for\b.*\(\s*$", line):
+            continue
+        depth = 0
+        block = []
+        for nested in lines[index:]:
+            block.append(nested)
+            depth += nested.count("(") - nested.count(")")
+            if depth == 0:
+                break
+        blocks.append("\n".join(block))
+    return blocks
+
+
 def bash_executable() -> str:
     bash = shutil.which("bash")
     if bash:
@@ -80,41 +110,314 @@ class CharacterUpdateRoutingTests(unittest.TestCase):
 
 
 class WardenBackupRoutingTests(unittest.TestCase):
-    EXPECTED_OPTIONAL_TABLES = {
-        ("%wdb%", "_full_worlddb", "%loadworldDB%", "warden"),
-        ("%wdb%", "_full_worlddb", "%loadworldDB%", "warden_checks"),
-        ("%cdb%", "_full_chardb", "%loadcharDB%", "warden_action"),
-        ("%rdb%", "_full_realmdb", "%loadrealmDB%", "warden_log"),
-        ("%rdb%", "_full_realmdb", "%loadrealmDB%", "warden_incident"),
-        ("%rdb%", "_full_realmdb", "%loadrealmDB%", "warden_audit"),
-    }
+    def test_optional_groups_are_called_in_exact_order(self) -> None:
+        expected_groups = [
+            ('"%wdb%"', '"_full_worlddb"', '"%loadworldDB%"', '"YES"',
+             '"warden"', '"warden_checks"'),
+            ('"%cdb%"', '"_full_chardb"', '"%loadcharDB%"', '"NO"',
+             '"warden_action"'),
+            ('"%rdb%"', '"_full_realmdb"', '"%loadrealmDB%"', '"YES"',
+             '"warden_log"', '"warden_incident"', '"warden_audit"'),
+        ]
 
-    def optional_calls(self) -> set[tuple[str, str, str, str]]:
-        return set(
-            re.findall(
-                r'(?im)^call :DumpOptionalTable "([^"]+)" "([^"]+)" '
-                r'"([^"]+)" "([^"]+)"\s*$',
-                BACKUP,
-            )
-        )
-
-    def test_legacy_and_replacement_tables_are_both_optional(self) -> None:
-        self.assertEqual(self.optional_calls(), self.EXPECTED_OPTIONAL_TABLES)
-        self.assertNotRegex(
-            BACKUP,
-            r"(?im)^SET TABLENAME=(warden|warden_checks|warden_action|"
-            r"warden_log|warden_incident|warden_audit)\s*$",
-        )
-
-    def test_optional_table_probe_distinguishes_absence_from_failure(self) -> None:
-        helper = batch_label("DumpOptionalTable", "patherror")
-        self.assertIn("information_schema.tables", helper)
-        self.assertIn('if not "%OPTIONALFOUND%" == "0" if not ', helper)
-        self.assertIn("exit /b 1", helper)
+        calls = [
+            tuple(re.findall(r'"[^"]+"', line))
+            for line in BACKUP.splitlines()
+            if line.startswith("call :DumpOptionalGroup ")
+        ]
+        self.assertEqual(calls, expected_groups)
+        self.assertNotIn("call :DumpOptionalTable ", BACKUP)
         self.assertEqual(
-            len(re.findall(r"(?im)^if errorlevel 1 goto error\s*$", BACKUP)),
-            len(self.EXPECTED_OPTIONAL_TABLES),
+            len(re.findall(r"(?im)^if errorlevel 1 goto error\s*$", BACKUP)), 3
         )
+
+    def test_optional_group_phases_publish_before_absent_cleanup(self) -> None:
+        labels = [
+            "DumpOptionalGroup",
+            "ProbeOptionalTable",
+            "StageOptionalTable",
+            "CleanupOptionalGroupArtifacts",
+            "DumpOptionalGroupRetainEmpty",
+            "DumpOptionalGroupFailed",
+        ]
+        actual = re.findall(
+            r"(?m)^:(DumpOptionalGroup|ProbeOptionalTable|StageOptionalTable|"
+            r"CleanupOptionalGroupArtifacts|DumpOptionalGroupRetainEmpty|"
+            r"DumpOptionalGroupFailed)\s*$",
+            BACKUP,
+        )
+        self.assertEqual(actual, labels)
+
+        group = batch_label("DumpOptionalGroup", "ProbeOptionalTable")
+        preflight = group[: group.index("call :ProbeOptionalTable")]
+        self.assertIn(
+            "for %%S in (exists.tmp dump.tmp sql.new present.tmp absent.tmp) do (",
+            preflight,
+        )
+        probe = group.index("call :ProbeOptionalTable")
+        stage = group.index("call :StageOptionalTable")
+        publish = group.index('move /Y "!OPTIONALREADY!" "!OPTIONALOUTPUT!"')
+        cleanup = group.index('del /Q "!OPTIONALOUTPUT!"', publish)
+        self.assertLess(probe, stage)
+        self.assertLess(stage, publish)
+        self.assertLess(publish, cleanup)
+        self.assertNotIn('del /Q "!OPTIONALOUTPUT!"', group[:publish])
+        self.assertIn(
+            'if "!OPTIONALPRESENT!" == "0" if /I "!OPTIONALRETAINEMPTY!" == "YES"',
+            group,
+        )
+        self.assertRegex(
+            group,
+            r"(?s)call :CleanupOptionalGroupArtifacts.*?endlocal\s+exit /b 0\s*$",
+        )
+
+    def test_probe_and_cleanup_reject_unsafe_artifacts_and_results(self) -> None:
+        probe = batch_label("ProbeOptionalTable", "StageOptionalTable")
+        query = probe.index("information_schema.tables")
+        before_query = probe[:query]
+        for suffix in (".exists.tmp", ".present.tmp", ".absent.tmp"):
+            assignment = re.search(
+                rf'(?m)^set "([A-Z]+)=[^"\r\n]*{re.escape(suffix)}"\s*$',
+                before_query,
+            )
+            self.assertIsNotNone(assignment, f"missing {suffix} marker")
+            marker = f"%{assignment.group(1)}%"
+            marker_lines = before_query.splitlines()
+            deletion_line = f'if exist "{marker}" del /Q "{marker}"'
+            self.assertIn(deletion_line, marker_lines, f"{suffix} is not cleared")
+            deletion = marker_lines.index(deletion_line)
+            verification = next(
+                (
+                    index
+                    for index, line in enumerate(marker_lines[deletion + 1 :], deletion + 1)
+                    if line.startswith(f'if exist "{marker}"')
+                ),
+                -1,
+            )
+            self.assertGreater(
+                verification, deletion, f"{suffix} removal is not verified"
+            )
+            verification_line = marker_lines[verification]
+            if verification_line == f'if exist "{marker}" exit /b 1':
+                continue
+            self.assertEqual(
+                verification_line,
+                f'if exist "{marker}" (',
+                f"{suffix} verification does not propagate failure",
+            )
+            verification_end = next(
+                (
+                    index
+                    for index, line in enumerate(
+                        marker_lines[verification + 1 :], verification + 1
+                    )
+                    if line == ")"
+                ),
+                -1,
+            )
+            self.assertGreater(verification_end, verification)
+            self.assertIn(
+                "exit /b 1",
+                (line.strip() for line in marker_lines[verification:verification_end]),
+                f"{suffix} verification does not return failure",
+            )
+
+        probe_lines = probe.splitlines()
+        query_line = next(
+            index
+            for index, line in enumerate(probe_lines)
+            if line.startswith('"%mysql%mysql.exe"')
+        )
+        self.assertEqual(probe_lines[query_line + 1], "if errorlevel 1 (")
+        query_guard_end = next(
+            index
+            for index, line in enumerate(probe_lines[query_line + 2 :], query_line + 2)
+            if line == ")"
+        )
+        self.assertIn(
+            "exit /b 1",
+            (line.strip() for line in probe_lines[query_line + 1 : query_guard_end]),
+        )
+
+        accepted = re.findall(
+            r'(?m)^if "%OPTIONALFOUND%" == "([^"]+)" \($', probe
+        )
+        self.assertEqual(accepted, ["0", "1"])
+        self.assertIn("exit /b 1", probe)
+
+        cleanup = batch_label(
+            "CleanupOptionalGroupArtifacts", "DumpOptionalGroupRetainEmpty"
+        )
+        self.assertIn(
+            "for %%S in (exists.tmp dump.tmp sql.new present.tmp absent.tmp) do (",
+            cleanup,
+        )
+        self.assertNotRegex(cleanup, r"(?i)\.sql(?!\.new)")
+        self.assertEqual(cleanup.count("setlocal"), 1)
+        self.assertEqual(cleanup.count("endlocal"), 2)
+        self.assertRegex(
+            cleanup,
+            r'(?s)if "!OPTIONALFAILED!" == "1" \(\s*'
+            r'endlocal\s+exit /b 1\s*\)\s*endlocal\s+exit /b 0\s*$',
+        )
+
+    def test_group_loops_record_failure_and_helper_region_is_crlf(self) -> None:
+        helper = batch_helper_region(BACKUP)
+        self.assertNotRegex(
+            helper, r'(?i)del /Q "[^"\r\n]*\*[^"\r\n]*"'
+        )
+        group = batch_label("DumpOptionalGroup", "ProbeOptionalTable")
+        cleanup = batch_label(
+            "CleanupOptionalGroupArtifacts", "DumpOptionalGroupRetainEmpty"
+        )
+        blocks = batch_for_blocks(group) + batch_for_blocks(cleanup)
+        self.assertTrue(blocks, "optional-group loops are missing")
+        for block in blocks:
+            self.assertNotRegex(block, r"(?i)\bgoto\b")
+
+        def assert_guarded(
+            body: str, operation: str, failure_guard: str
+        ) -> None:
+            self.assertEqual(body.count(operation), 1)
+            self.assertRegex(
+                body,
+                re.escape(operation) + r"\s*" + re.escape(failure_guard),
+            )
+
+        group_artifact = r'"!OPTIONALDIR!\%%~T.%%S"'
+        assert_guarded(
+            group,
+            f"if exist {group_artifact} del /Q {group_artifact}",
+            f'if exist {group_artifact} set "OPTIONALFAILED=1"',
+        )
+        assert_guarded(
+            group,
+            'call :ProbeOptionalTable "!OPTIONALDB!" "!OPTIONALDIR!" "%%~T"',
+            'if errorlevel 1 set "OPTIONALFAILED=1"',
+        )
+        assert_guarded(
+            group,
+            'call :StageOptionalTable "!OPTIONALDB!" "!OPTIONALDIR!" '
+            '"!OPTIONALSTRUCTURE!" "%%~T"',
+            'if errorlevel 1 set "OPTIONALFAILED=1"',
+        )
+        assert_guarded(
+            group,
+            'move /Y "!OPTIONALREADY!" "!OPTIONALOUTPUT!" >nul',
+            'if errorlevel 1 set "OPTIONALFAILED=1"',
+        )
+        assert_guarded(
+            group,
+            'if exist "!OPTIONALOUTPUT!" del /Q "!OPTIONALOUTPUT!"',
+            'if exist "!OPTIONALOUTPUT!" set "OPTIONALFAILED=1"',
+        )
+        assert_guarded(
+            group,
+            'call :CleanupOptionalGroupArtifacts "!OPTIONALDIR!" "%~5" "%~6" "%~7"',
+            "if errorlevel 1 goto DumpOptionalGroupFailed",
+        )
+        cleanup_artifact = r'"!OPTIONALDIR!\%%~T.%%S"'
+        assert_guarded(
+            cleanup,
+            f"if exist {cleanup_artifact} del /Q {cleanup_artifact}",
+            f'if exist {cleanup_artifact} set "OPTIONALFAILED=1"',
+        )
+
+        probe = batch_label("ProbeOptionalTable", "StageOptionalTable")
+        self.assertEqual(
+            probe.splitlines()[0],
+            "setlocal EnableExtensions DisableDelayedExpansion",
+        )
+        self.assertNotRegex(probe, r"(?i)\bgoto\b")
+        stage = batch_label("StageOptionalTable", "CleanupOptionalGroupArtifacts")
+        self.assertEqual(
+            stage.splitlines()[0],
+            "setlocal EnableExtensions DisableDelayedExpansion",
+        )
+        stage_lines = stage.splitlines()
+        dump_line = next(
+            index
+            for index, line in enumerate(stage_lines)
+            if line.startswith('"%mysql%mysqldump.exe"')
+        )
+        self.assertEqual(stage_lines[dump_line + 1], "if errorlevel 1 (")
+        dump_guard_end = next(
+            index
+            for index, line in enumerate(stage_lines[dump_line + 2 :], dump_line + 2)
+            if line == ")"
+        )
+        self.assertIn(
+            "exit /b 1",
+            (line.strip() for line in stage_lines[dump_line + 1 : dump_guard_end]),
+        )
+        stage_preflight = "\n".join(stage_lines[:dump_line])
+        for artifact in ("%OPTIONALTEMP%", "%OPTIONALREADY%"):
+            assert_guarded(
+                stage_preflight,
+                f'if exist "{artifact}" del /Q "{artifact}"',
+                f'if exist "{artifact}" (',
+            )
+            verification = stage_preflight.index(f'if exist "{artifact}" (')
+            verification_end = stage_preflight.index("\n)", verification)
+            self.assertIn(
+                "exit /b 1", stage_preflight[verification:verification_end]
+            )
+
+        child_commands = [
+            index
+            for index, line in enumerate(stage_lines)
+            if line.lstrip().startswith("%ComSpec% /D /C ")
+        ]
+        self.assertEqual(len(child_commands), 6)
+        assembly_failures = []
+        for index in child_commands:
+            guard = stage_lines[index + 1].strip()
+            match = re.fullmatch(
+                r"if errorlevel 1 goto ([A-Za-z0-9_]+)", guard
+            )
+            self.assertIsNotNone(match, f"unguarded child command: {stage_lines[index]}")
+            assembly_failures.append(match.group(1))
+        self.assertEqual(len(set(assembly_failures)), 1)
+        assembly_target = assembly_failures[0]
+        delete_guard = re.search(
+            r'(?s)del /Q "%OPTIONALTEMP%"\s*'
+            r'if exist "%OPTIONALTEMP%" goto ([A-Za-z0-9_]+)',
+            stage,
+        )
+        self.assertIsNotNone(delete_guard)
+        self.assertEqual(delete_guard.group(1), assembly_target)
+        move_guard = re.search(
+            r'(?s)move /Y "%OPTIONALTEMP%" "%OPTIONALREADY%" >nul\s*'
+            r'if errorlevel 1 goto ([A-Za-z0-9_]+)',
+            stage,
+        )
+        self.assertIsNotNone(move_guard)
+        self.assertEqual(move_guard.group(1), assembly_target)
+        self.assertRegex(
+            stage, rf"(?m)^:{re.escape(assembly_target)}\s*$"
+        )
+
+        raw = (ROOT / "Tools" / "backupDB.cmd").read_bytes()
+        raw.decode("utf-8")
+        normalized = raw.replace(b"\r\n", b"\n")
+        start = normalized.find(b":DumpOptionalGroup\n")
+        self.assertGreaterEqual(start, 0, "DumpOptionalGroup label is missing")
+        end = normalized.find(b"\n:patherror", start)
+        self.assertGreater(end, start, "optional-group helper region is unterminated")
+        self.assertTrue(normalized[start:end].startswith(b":DumpOptionalGroup\n"))
+        if os.name == "nt":
+            windows_start = raw.find(b":DumpOptionalGroup\r\n")
+            self.assertGreaterEqual(
+                windows_start, 0, "DumpOptionalGroup CRLF label is missing"
+            )
+            windows_end = raw.find(b"\r\n:patherror", windows_start)
+            self.assertGreater(
+                windows_end,
+                windows_start,
+                "optional-group CRLF helper region is unterminated",
+            )
+            windows_region = raw[windows_start:windows_end]
+            self.assertNotIn(b"\n", windows_region.replace(b"\r\n", b""))
 
     def test_script_returns_failure_to_automation(self) -> None:
         self.assertIn('set "BACKUPRESULT=0"', BACKUP)
@@ -124,67 +427,159 @@ class WardenBackupRoutingTests(unittest.TestCase):
             r"(?ms)^:finish\s*$\s*pause\s*exit /b %BACKUPRESULT%\s*$",
         )
 
-    def test_absence_removes_only_the_exact_stale_output_after_probe(self) -> None:
-        helper = batch_label("DumpOptionalTable", "patherror")
-        validated = helper.index(
-            'if not "%OPTIONALFOUND%" == "0" if not '
+    @unittest.skipUnless(os.name == "nt", "cmd.exe behavior requires Windows")
+    def test_optional_group_runtime_safety(self) -> None:
+        region = batch_helper_region(BACKUP)
+        region, probe_replacements = re.subn(
+            r'(?m)^"%mysql%mysql\.exe".* > "%OPTIONALPROBE%" 2>nul[ \t]*$',
+            'call :FakeMysql "%OPTIONALTABLE%" "%OPTIONALPROBE%"',
+            region,
         )
-        absent = helper.index('if "%OPTIONALFOUND%" == "0" (')
-        deletion = helper.index(
-            'if exist "%OPTIONALOUTPUT%" del /Q "%OPTIONALOUTPUT%"'
+        region, dump_replacements = re.subn(
+            r'(?m)^"%mysql%mysqldump\.exe".* > "%OPTIONALTEMP%"[ \t]*$',
+            'call :FakeDump "%OPTIONALTABLE%" "%OPTIONALTEMP%"',
+            region,
         )
-        self.assertLess(validated, absent)
-        self.assertLess(absent, deletion)
-        self.assertEqual(
-            helper.count(
-                'if exist "%OPTIONALOUTPUT%" del /Q "%OPTIONALOUTPUT%"'
-            ),
-            1,
-        )
-        absent_branch = helper[absent : helper.index('set "OPTIONALPARAMS="')]
-        self.assertRegex(
-            absent_branch,
-            r'(?s)del /Q "%OPTIONALOUTPUT%"\s*'
-            r'if exist "%OPTIONALOUTPUT%" \(.*?exit /b 1',
-        )
-        self.assertNotRegex(helper, r'del /Q "[^"\r\n]*\*[^"\r\n]*"')
+        self.assertEqual(probe_replacements, 1)
+        self.assertEqual(dump_replacements, 1)
 
-    def test_present_table_output_is_published_only_after_complete_dump(self) -> None:
-        helper = batch_label("DumpOptionalTable", "patherror")
-        dump = helper.index('> "%OPTIONALTEMP%"')
-        ready = helper.index('move /Y "%OPTIONALTEMP%" "%OPTIONALREADY%"')
-        publish = helper.index(
-            'move /Y "%OPTIONALREADY%" "%OPTIONALOUTPUT%" >nul'
-        )
-        self.assertLess(dump, ready)
-        self.assertLess(ready, publish)
-        self.assertNotIn('>> "%OPTIONALOUTPUT%"', helper)
-
-    def test_data_only_assembly_failure_preserves_previous_output(self) -> None:
-        helper = batch_label("DumpOptionalTable", "patherror")
-        assembly = helper[
-            helper.index('if /I "%OPTIONALSTRUCTURE%" == "NO" (') :
-            helper.index('move /Y "%OPTIONALREADY%" "%OPTIONALOUTPUT%"')
-        ]
-        writes = [
-            '%ComSpec% /D /C echo -- ---------------------------------------- ^> "%OPTIONALREADY%"',
-            '%ComSpec% /D /C echo -- --        CLEAR DOWN THE TABLE        -- ^>^> "%OPTIONALREADY%"',
-            '%ComSpec% /D /C echo -- ---------------------------------------- ^>^> "%OPTIONALREADY%"',
-            '%ComSpec% /D /C echo TRUNCATE TABLE `%OPTIONALTABLE%`; ^>^> "%OPTIONALREADY%"',
-            '%ComSpec% /D /C type "%OPTIONALTEMP%" ^>^> "%OPTIONALREADY%"',
-        ]
-        for write in writes:
-            self.assertRegex(
-                assembly,
-                re.escape(write)
-                + r"\s*if errorlevel 1 goto DumpOptionalTableAssemblyFailed",
+        def run_case(
+            directory: Path,
+            retain_empty: str,
+            tables: tuple[str, ...],
+            present: dict[str, str],
+            fail_stage_table: str = "",
+        ) -> subprocess.CompletedProcess[str]:
+            assignments = [
+                f'set "PRESENT_{table}={value}"'
+                for table, value in present.items()
+            ]
+            table_args = " ".join(f'"{table}"' for table in tables)
+            harness = "\n".join(
+                [
+                    "@echo off",
+                    "setlocal EnableExtensions EnableDelayedExpansion",
+                    'set "mysql="',
+                    'set "user=test"',
+                    'set "pass=test"',
+                    'set "port=3306"',
+                    'set "svr=localhost"',
+                    f'set "FAIL_STAGE_TABLE={fail_stage_table}"',
+                    *assignments,
+                    f'call :DumpOptionalGroup "test" "{directory}" "YES" '
+                    f'"{retain_empty}" {table_args}',
+                    "exit /b %errorlevel%",
+                    region,
+                    ":FakeMysql",
+                    "setlocal EnableDelayedExpansion",
+                    '> "%~2" echo(!PRESENT_%~1!',
+                    "endlocal",
+                    "exit /b 0",
+                    ":FakeDump",
+                    "setlocal EnableDelayedExpansion",
+                    'if /I "!FAIL_STAGE_TABLE!" == "%~1" exit /b 1',
+                    '> "%~2" echo(-- deterministic dump for %~1',
+                    "endlocal",
+                    "exit /b 0",
+                    "",
+                ]
             )
-        self.assertRegex(
-            assembly,
-            r'(?s)del /Q "%OPTIONALTEMP%"\s*'
-            r'if exist "%OPTIONALTEMP%" goto DumpOptionalTableAssemblyFailed',
-        )
-        self.assertIn(":DumpOptionalTableAssemblyFailed", BACKUP)
+            batch = directory / "run-group.cmd"
+            batch.write_bytes(harness.replace("\n", "\r\n").encode("utf-8"))
+            return subprocess.run(
+                ["cmd.exe", "/d", "/c", str(batch)],
+                cwd=directory,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+
+            stage_failure = root / "stage-failure"
+            stage_failure.mkdir()
+            stage_failure_prior = b"prior world warden backup\r\n"
+            (stage_failure / "warden.sql").write_bytes(stage_failure_prior)
+            result = run_case(
+                stage_failure,
+                "YES",
+                ("warden", "warden_checks"),
+                {"warden": "0", "warden_checks": "1"},
+                "warden_checks",
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertEqual(
+                (stage_failure / "warden.sql").read_bytes(), stage_failure_prior
+            )
+
+            stale_marker = root / "stale-marker"
+            stale_marker.mkdir()
+            (stale_marker / "warden.absent.tmp").write_text(
+                "stale", encoding="utf-8"
+            )
+            result = run_case(
+                stale_marker,
+                "YES",
+                ("warden", "warden_checks"),
+                {"warden": "1", "warden_checks": "0"},
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertFalse((stale_marker / "warden.absent.tmp").exists())
+            self.assertIn(
+                "deterministic dump for warden",
+                (stale_marker / "warden.sql").read_text(encoding="utf-8"),
+            )
+
+            character_absent = root / "character-absent"
+            character_absent.mkdir()
+            (character_absent / "warden_action.sql").write_text(
+                "prior", encoding="utf-8"
+            )
+            result = run_case(
+                character_absent,
+                "NO",
+                ("warden_action",),
+                {"warden_action": "0"},
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertFalse((character_absent / "warden_action.sql").exists())
+
+            world_empty = root / "world-empty"
+            world_empty.mkdir()
+            world_empty_prior = {
+                "warden": b"prior world warden backup\r\n",
+                "warden_checks": b"prior world warden-checks backup\r\n",
+            }
+            for table, prior in world_empty_prior.items():
+                (world_empty / f"{table}.sql").write_bytes(prior)
+            result = run_case(
+                world_empty,
+                "YES",
+                ("warden", "warden_checks"),
+                {"warden": "0", "warden_checks": "0"},
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            for table, prior in world_empty_prior.items():
+                self.assertEqual((world_empty / f"{table}.sql").read_bytes(), prior)
+
+            invalid_probe = root / "invalid-probe"
+            invalid_probe.mkdir()
+            invalid_probe_prior = {
+                "warden": b"prior invalid-probe warden backup\r\n",
+                "warden_checks": b"prior invalid-probe warden-checks backup\r\n",
+            }
+            for table, prior in invalid_probe_prior.items():
+                (invalid_probe / f"{table}.sql").write_bytes(prior)
+            result = run_case(
+                invalid_probe,
+                "YES",
+                ("warden", "warden_checks"),
+                {"warden": "2", "warden_checks": "1"},
+            )
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            for table, prior in invalid_probe_prior.items():
+                self.assertEqual((invalid_probe / f"{table}.sql").read_bytes(), prior)
 
 
 class WardenUnixDumpRoutingTests(unittest.TestCase):
@@ -222,6 +617,41 @@ class WardenUnixDumpRoutingTests(unittest.TestCase):
             r"(?ms)^dump_warden_tables\(\)\s*\{.*?^\}\s*$",
         )
         self.assertNotRegex(DUMP, r"(?m)^`warden(?:_checks)?` \\$")
+
+    def test_unix_dump_retains_prior_warden_files_when_no_tables_exist(self) -> None:
+        function = re.search(
+            r"(?ms)^dump_warden_tables\(\)\s*\{.*?^\}\s*$", DUMP
+        )
+        self.assertIsNotNone(function, "dump_warden_tables is missing")
+        harness = "\n".join(
+            (
+                function.group(0),
+                "mysql() { printf '0\\n'; }",
+                "mysqldump() { return 99; }",
+                "USERNAME=test",
+                "PASSWORD=test",
+                "DB=test_world",
+                'DUMPDIR="$1"',
+                'touch "${DUMPDIR}/warden.sql" "${DUMPDIR}/warden_checks.sql"',
+                "set -e",
+                "dump_warden_tables",
+                "status=$?",
+                "test ${status} -eq 0",
+                'test -f "${DUMPDIR}/warden.sql"',
+                'test -f "${DUMPDIR}/warden_checks.sql"',
+            )
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            result = subprocess.run(
+                [bash_executable(), "-c", harness, "dump-warden-harness", temporary],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("Neither warden nor warden_checks exists", result.stderr)
+            self.assertTrue((Path(temporary) / "warden.sql").is_file())
+            self.assertTrue((Path(temporary) / "warden_checks.sql").is_file())
 
     def test_complete_unix_dump_script_parses_and_iterates_tables(self) -> None:
         result = subprocess.run(

--- a/Tools/tests/test_warden_transition_scripts.py
+++ b/Tools/tests/test_warden_transition_scripts.py
@@ -23,6 +23,8 @@
 
 from pathlib import Path
 import re
+import shutil
+import subprocess
 import unittest
 
 
@@ -50,6 +52,18 @@ def batch_label(name: str, next_label: str) -> str:
     if not match:
         raise AssertionError(f"missing batch label {name}")
     return match.group(1)
+
+
+def bash_executable() -> str:
+    bash = shutil.which("bash")
+    if bash:
+        return bash
+    git = shutil.which("git")
+    if git:
+        candidate = Path(git).resolve().parents[1] / "bin" / "bash.exe"
+        if candidate.is_file():
+            return str(candidate)
+    raise AssertionError("bash is required to validate dump_tables.sh")
 
 
 class CharacterUpdateRoutingTests(unittest.TestCase):
@@ -102,6 +116,14 @@ class WardenBackupRoutingTests(unittest.TestCase):
             len(self.EXPECTED_OPTIONAL_TABLES),
         )
 
+    def test_script_returns_failure_to_automation(self) -> None:
+        self.assertIn('set "BACKUPRESULT=0"', BACKUP)
+        self.assertEqual(BACKUP.count('set "BACKUPRESULT=1"'), 2)
+        self.assertRegex(
+            BACKUP,
+            r"(?ms)^:finish\s*$\s*pause\s*exit /b %BACKUPRESULT%\s*$",
+        )
+
     def test_absence_removes_only_the_exact_stale_output_after_probe(self) -> None:
         helper = batch_label("DumpOptionalTable", "patherror")
         validated = helper.index(
@@ -119,6 +141,12 @@ class WardenBackupRoutingTests(unittest.TestCase):
             ),
             1,
         )
+        absent_branch = helper[absent : helper.index('set "OPTIONALPARAMS="')]
+        self.assertRegex(
+            absent_branch,
+            r'(?s)del /Q "%OPTIONALOUTPUT%"\s*'
+            r'if exist "%OPTIONALOUTPUT%" \(.*?exit /b 1',
+        )
         self.assertNotRegex(helper, r'del /Q "[^"\r\n]*\*[^"\r\n]*"')
 
     def test_present_table_output_is_published_only_after_complete_dump(self) -> None:
@@ -132,28 +160,88 @@ class WardenBackupRoutingTests(unittest.TestCase):
         self.assertLess(ready, publish)
         self.assertNotIn('>> "%OPTIONALOUTPUT%"', helper)
 
+    def test_data_only_assembly_failure_preserves_previous_output(self) -> None:
+        helper = batch_label("DumpOptionalTable", "patherror")
+        assembly = helper[
+            helper.index('if /I "%OPTIONALSTRUCTURE%" == "NO" (') :
+            helper.index('move /Y "%OPTIONALREADY%" "%OPTIONALOUTPUT%"')
+        ]
+        writes = [
+            '%ComSpec% /D /C echo -- ---------------------------------------- ^> "%OPTIONALREADY%"',
+            '%ComSpec% /D /C echo -- --        CLEAR DOWN THE TABLE        -- ^>^> "%OPTIONALREADY%"',
+            '%ComSpec% /D /C echo -- ---------------------------------------- ^>^> "%OPTIONALREADY%"',
+            '%ComSpec% /D /C echo TRUNCATE TABLE `%OPTIONALTABLE%`; ^>^> "%OPTIONALREADY%"',
+            '%ComSpec% /D /C type "%OPTIONALTEMP%" ^>^> "%OPTIONALREADY%"',
+        ]
+        for write in writes:
+            self.assertRegex(
+                assembly,
+                re.escape(write)
+                + r"\s*if errorlevel 1 goto DumpOptionalTableAssemblyFailed",
+            )
+        self.assertRegex(
+            assembly,
+            r'(?s)del /Q "%OPTIONALTEMP%"\s*'
+            r'if exist "%OPTIONALTEMP%" goto DumpOptionalTableAssemblyFailed',
+        )
+        self.assertIn(":DumpOptionalTableAssemblyFailed", BACKUP)
+
 
 class WardenUnixDumpRoutingTests(unittest.TestCase):
-    def test_selects_existing_warden_tables_and_cleans_stale_counterparts(self) -> None:
+    def test_replaces_warden_dumps_only_after_successful_staging(self) -> None:
         candidates = re.search(r"for WARDEN_TABLE in ([^;\n]+); do", DUMP)
         self.assertIsNotNone(candidates, "Warden table probe loop is missing")
         self.assertEqual(candidates.group(1).split(), ["warden", "warden_checks"])
         self.assertRegex(
             DUMP,
             r"(?s)for WARDEN_TABLE in warden warden_checks; do.*?"
-            r"mysqldump .*--no-data.*\$\{DB\}.*\$\{WARDEN_TABLE\}",
+            r"WARDEN_FOUND=.*?mysql .*information_schema\.tables",
         )
+        self.assertIn('case "${WARDEN_FOUND}" in', DUMP)
 
-        refusal = DUMP.index('if [ -z "${WARDEN_TABLES}" ]; then')
-        cleanup = DUMP.index(
-            'rm -f "${DUMPDIR}/warden.sql" "${DUMPDIR}/warden_checks.sql"'
+        self.assertIn('> "${WARDEN_READY}"', DUMP)
+        stage = DUMP.index('> "${WARDEN_READY}"')
+        publish = DUMP.index(
+            'mv -f "${WARDEN_READY}" "${DUMPDIR}/${WARDEN_TABLE}.sql"'
         )
-        table_loop = DUMP.index("for TABLE in \\")
-        self.assertLess(refusal, cleanup)
-        self.assertLess(cleanup, table_loop)
+        stale_cleanup = DUMP.index(
+            'rm -f "${DUMPDIR}/${WARDEN_TABLE}.sql"', publish
+        )
+        self.assertLess(stage, publish)
+        self.assertLess(publish, stale_cleanup)
+        self.assertIn('if ! mysqldump ', DUMP)
+        self.assertIn('if ! mv -f "${WARDEN_READY}"', DUMP)
         self.assertIn("Neither warden nor warden_checks exists", DUMP)
-        self.assertIn("${WARDEN_TABLES} \\", DUMP)
+        self.assertNotIn(
+            'rm -f "${DUMPDIR}/warden.sql" "${DUMPDIR}/warden_checks.sql"',
+            DUMP,
+        )
+        self.assertNotIn("${WARDEN_TABLES} \\", DUMP)
+        self.assertRegex(
+            DUMP,
+            r"(?ms)^dump_warden_tables\(\)\s*\{.*?^\}\s*$",
+        )
         self.assertNotRegex(DUMP, r"(?m)^`warden(?:_checks)?` \\$")
+
+    def test_complete_unix_dump_script_parses_and_iterates_tables(self) -> None:
+        result = subprocess.run(
+            [bash_executable(), "-n", str(ROOT / "Tools" / "dump_tables.sh")],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        loop = re.search(r"(?ms)^for TABLE in [\\]\r?\n.*?^; do\s*$", DUMP)
+        self.assertIsNotNone(loop, "generic table loop is missing")
+        iteration = subprocess.run(
+            [bash_executable(), "-c", loop.group(0) + '\nprintf "%s\\n" "$TABLE"\ndone\n'],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        self.assertEqual(iteration.returncode, 0, iteration.stderr)
+        self.assertGreater(len(iteration.stdout.splitlines()), 100)
 
 
 if __name__ == "__main__":

--- a/Tools/tests/test_warden_transition_scripts.py
+++ b/Tools/tests/test_warden_transition_scripts.py
@@ -46,6 +46,17 @@ def shell_function(name: str) -> str:
     return match.group(1)
 
 
+def dump_shell_function(name: str) -> str:
+    dump_text = (ROOT / "Tools" / "dump_tables.sh").read_text(encoding="utf-8")
+    match = re.search(
+        rf"(?ms)^{re.escape(name)}\(\)\s*\{{.*?^\}}\s*$",
+        dump_text,
+    )
+    if not match:
+        raise AssertionError(f"missing dump function {name}")
+    return match.group(0)
+
+
 def batch_label(name: str, next_label: str) -> str:
     match = re.search(
         rf"(?ms)^:{re.escape(name)}\s*$\s*(.*?)^:{re.escape(next_label)}\s*$",
@@ -672,6 +683,294 @@ class WardenUnixDumpRoutingTests(unittest.TestCase):
         )
         self.assertEqual(iteration.returncode, 0, iteration.stderr)
         self.assertGreater(len(iteration.stdout.splitlines()), 100)
+
+
+class BackupPublicationRollbackTests(unittest.TestCase):
+    def test_windows_recovery_contract_is_explicit_and_non_wildcard(self) -> None:
+        helper = batch_helper_region(BACKUP)
+        self.assertIn(".sql.rollback.tmp", helper)
+        self.assertIn(".sql.no-prior.tmp", helper)
+        self.assertRegex(helper, r"(?m)^:RestoreOptionalGroup\s*$")
+        self.assertRegex(helper, r"(?m)^:RecoverOptionalGroupAtEntry\s*$")
+        self.assertNotRegex(helper, r'(?i)del /Q "[^"\r\n]*\*[^"\r\n]*"')
+
+        restore = batch_label("RestoreOptionalGroup", "patherror")
+        failure = re.search(
+            r'(?s)if "!OPTIONALFAILED!" == "1" \(\s*'
+            r'endlocal\s+exit /b 1\s*\)',
+            restore,
+        )
+        self.assertIsNotNone(
+            failure, "rollback failure must return without recovery cleanup"
+        )
+        failed = batch_label(
+            "DumpOptionalGroupFailed", "DumpOptionalGroupRecoveryCleanupFailed"
+        )
+        self.assertRegex(
+            failed,
+            r"(?s)call :RestoreOptionalGroup .*?\s+"
+            r"if errorlevel 1 goto DumpOptionalGroupRollbackFailed",
+        )
+        rollback_failed = batch_label(
+            "DumpOptionalGroupRollbackFailed",
+            "DumpOptionalGroupRecoveryCleanupFailed",
+        )
+        self.assertIn("recovery artifacts remain", rollback_failed)
+
+    @unittest.skipUnless(os.name == "nt", "cmd.exe behavior requires Windows")
+    def test_windows_incomplete_entry_recovery_refuses_without_mutation(self) -> None:
+        region = batch_helper_region(BACKUP)
+        region, probe_replacements = re.subn(
+            r'(?m)^"%mysql%mysql\.exe".* > "%OPTIONALPROBE%" 2>nul[ \t]*$',
+            'call :UnexpectedMysql',
+            region,
+        )
+        region, dump_replacements = re.subn(
+            r'(?m)^"%mysql%mysqldump\.exe".* > "%OPTIONALTEMP%"[ \t]*$',
+            'call :UnexpectedDump',
+            region,
+        )
+        self.assertEqual(probe_replacements, 1)
+        self.assertEqual(dump_replacements, 1)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            published = {
+                "warden": b"newer published warden bytes\r\n\x00",
+                "warden_checks": b"newer published checks bytes\r\n\xff",
+            }
+            for table, content in published.items():
+                (root / f"{table}.sql").write_bytes(content)
+            rollback = root / "warden.sql.rollback.tmp"
+            rollback_bytes = b"older retained rollback bytes\r\n\x1a"
+            rollback.write_bytes(rollback_bytes)
+
+            harness = "\n".join(
+                (
+                    "@echo off",
+                    "setlocal EnableExtensions EnableDelayedExpansion",
+                    'set "mysql="',
+                    'set "user=test"',
+                    'set "pass=test"',
+                    'set "port=3306"',
+                    'set "svr=localhost"',
+                    f'call :DumpOptionalGroup "test" "{root}" "YES" "YES" '
+                    '"warden" "warden_checks"',
+                    "exit /b %errorlevel%",
+                    region,
+                    ":UnexpectedMysql",
+                    f'> "{root / "probe-called.flag"}" echo called',
+                    "exit /b 91",
+                    ":UnexpectedDump",
+                    f'> "{root / "dump-called.flag"}" echo called',
+                    "exit /b 92",
+                    "",
+                )
+            )
+            batch = root / "run-incomplete-recovery.cmd"
+            batch.write_bytes(harness.replace("\n", "\r\n").encode("utf-8"))
+            result = subprocess.run(
+                ["cmd.exe", "/d", "/c", str(batch)],
+                cwd=root,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            for table, content in published.items():
+                self.assertEqual((root / f"{table}.sql").read_bytes(), content)
+            self.assertTrue(rollback.is_file())
+            self.assertEqual(rollback.read_bytes(), rollback_bytes)
+            self.assertFalse((root / "probe-called.flag").exists())
+            self.assertFalse((root / "dump-called.flag").exists())
+            for table in published:
+                for suffix in (
+                    "exists.tmp",
+                    "dump.tmp",
+                    "sql.new",
+                    "present.tmp",
+                    "absent.tmp",
+                    "sql.no-prior.tmp",
+                ):
+                    self.assertFalse((root / f"{table}.{suffix}").exists())
+
+    @unittest.skipUnless(os.name == "nt", "cmd.exe behavior requires Windows")
+    def test_windows_publish_failure_restores_group_and_original_absence(self) -> None:
+        region = batch_helper_region(BACKUP)
+        region, probe_replacements = re.subn(
+            r'(?m)^"%mysql%mysql\.exe".* > "%OPTIONALPROBE%" 2>nul[ \t]*$',
+            'call :FakeMysql "%OPTIONALTABLE%" "%OPTIONALPROBE%"',
+            region,
+        )
+        region, dump_replacements = re.subn(
+            r'(?m)^"%mysql%mysqldump\.exe".* > "%OPTIONALTEMP%"[ \t]*$',
+            'call :FakeDump "%OPTIONALTABLE%" "%OPTIONALTEMP%"',
+            region,
+        )
+        region, move_replacements = re.subn(
+            r'(?m)^(\s*)move /Y (.*)$', r'\1call :FakeMove \2', region
+        )
+        self.assertEqual(probe_replacements, 1)
+        self.assertEqual(dump_replacements, 1)
+        self.assertGreaterEqual(move_replacements, 3)
+
+        def run_case(directory: Path, absent_first: bool) -> subprocess.CompletedProcess[str]:
+            harness = "\n".join(
+                (
+                    "@echo off",
+                    "setlocal EnableExtensions EnableDelayedExpansion",
+                    'set "mysql="',
+                    'set "user=test"',
+                    'set "pass=test"',
+                    'set "port=3306"',
+                    'set "svr=localhost"',
+                    'set "PRESENT_warden=1"',
+                    'set "PRESENT_warden_checks=1"',
+                    'set "FAIL_PUBLISH_TABLE=warden_checks"',
+                    f'call :DumpOptionalGroup "test" "{directory}" "YES" "YES" '
+                    '"warden" "warden_checks"',
+                    "exit /b %errorlevel%",
+                    region,
+                    ":FakeMysql",
+                    "setlocal EnableDelayedExpansion",
+                    '> "%~2" echo(!PRESENT_%~1!',
+                    "endlocal",
+                    "exit /b 0",
+                    ":FakeDump",
+                    '> "%~2" echo(new dump for %~1',
+                    "exit /b 0",
+                    ":FakeMove",
+                    'if /I "%~nx1" == "%FAIL_PUBLISH_TABLE%.sql.new" exit /b 71',
+                    'move /Y "%~1" "%~2" >nul',
+                    "exit /b %errorlevel%",
+                    "",
+                )
+            )
+            batch = directory / "run-rollback.cmd"
+            batch.write_bytes(harness.replace("\n", "\r\n").encode("utf-8"))
+            return subprocess.run(
+                ["cmd.exe", "/d", "/c", str(batch)],
+                cwd=directory,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            both_prior = root / "both-prior"
+            both_prior.mkdir()
+            prior = {
+                "warden": b"prior warden exact bytes\r\n\x1a",
+                "warden_checks": b"prior checks exact bytes\r\n\x00",
+            }
+            for table, content in prior.items():
+                (both_prior / f"{table}.sql").write_bytes(content)
+            result = run_case(both_prior, False)
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            for table, content in prior.items():
+                self.assertEqual((both_prior / f"{table}.sql").read_bytes(), content)
+            self.assertFalse(list(both_prior.glob("*.sql.new")))
+            self.assertFalse(list(both_prior.glob("*.sql.rollback.tmp")))
+            self.assertFalse(list(both_prior.glob("*.sql.no-prior.tmp")))
+
+            absent_first = root / "absent-first"
+            absent_first.mkdir()
+            checks_prior = b"prior checks only\r\n\xff"
+            (absent_first / "warden_checks.sql").write_bytes(checks_prior)
+            result = run_case(absent_first, True)
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertFalse((absent_first / "warden.sql").exists())
+            self.assertEqual(
+                (absent_first / "warden_checks.sql").read_bytes(), checks_prior
+            )
+            self.assertFalse(list(absent_first.glob("*.sql.new")))
+            self.assertFalse(list(absent_first.glob("*.sql.rollback.tmp")))
+            self.assertFalse(list(absent_first.glob("*.sql.no-prior.tmp")))
+
+    def test_unix_warden_publish_failure_restores_group(self) -> None:
+        function = "\n".join(
+            (
+                dump_shell_function("restore_warden_group"),
+                dump_shell_function("dump_warden_tables"),
+            )
+        )
+        harness = "\n".join(
+            (
+                function,
+                "mysql() { printf '1\\n'; }",
+                "mysqldump() { printf 'new dump for %s\\n' \"${@: -1}\"; }",
+                "mv() {",
+                '  if [ "${2##*/}" = "warden_checks.sql.new" ]; then return 71; fi',
+                '  command mv "$@"',
+                "}",
+                "USERNAME=test",
+                "PASSWORD=test",
+                "DB=test_world",
+                'DUMPDIR="$1"',
+                "dump_warden_tables",
+            )
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            prior = b"prior unix warden exact bytes\n\x00"
+            (root / "warden.sql").write_bytes(prior)
+            result = subprocess.run(
+                [bash_executable(), "-c", harness, "warden-rollback", temporary],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual((root / "warden.sql").read_bytes(), prior)
+            self.assertFalse((root / "warden_checks.sql").exists())
+            self.assertFalse(list(root.glob("*.sql.new")))
+            self.assertFalse(list(root.glob("*.sql.rollback.tmp")))
+            self.assertFalse(list(root.glob("*.sql.no-prior.tmp")))
+
+    def test_generic_unix_dump_stages_and_checks_pipeline(self) -> None:
+        function = dump_shell_function("dump_table")
+
+        def run_case(directory: Path, fail: bool) -> subprocess.CompletedProcess[str]:
+            dump_result = "return 42" if fail else "return 0"
+            harness = "\n".join(
+                (
+                    function,
+                    "mysqldump() {",
+                    "  printf 'h1\\nh2\\nh3\\nh4\\nh5\\nh6\\nINSERT INTO sample VALUES (1);\\n'",
+                    f"  {dump_result}",
+                    "}",
+                    "USERNAME=test",
+                    "PASSWORD=test",
+                    "DB=test_world",
+                    'DUMPDIR="$1"',
+                    "dump_table sample",
+                )
+            )
+            return subprocess.run(
+                [bash_executable(), "-c", harness, "generic-dump", str(directory)],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            destination = root / "sample.sql"
+            prior = b"prior generic exact bytes\n\xff"
+            destination.write_bytes(prior)
+            failed = run_case(root, True)
+            self.assertNotEqual(failed.returncode, 0, failed.stdout + failed.stderr)
+            self.assertEqual(destination.read_bytes(), prior)
+            self.assertFalse((root / "sample.sql.new").exists())
+
+            succeeded = run_case(root, False)
+            self.assertEqual(succeeded.returncode, 0, succeeded.stdout + succeeded.stderr)
+            published = destination.read_text(encoding="utf-8")
+            self.assertTrue(published.startswith("--\n-- Copyright"))
+            self.assertIn("INSERT INTO sample VALUES\n(1);", published)
+            self.assertFalse((root / "sample.sql.new").exists())
 
 
 if __name__ == "__main__":

--- a/Tools/tests/test_warden_transition_scripts.py
+++ b/Tools/tests/test_warden_transition_scripts.py
@@ -113,11 +113,57 @@ class CharacterUpdateRoutingTests(unittest.TestCase):
         self.assertRegex(
             execution,
             re.escape('if [ "${updatecharDB}" = "YES" ]; then')
-            + r"(?s:\s*updateCharDB\s*fi)",
+            + r"(?s:\s*if ! updateCharDB; then\s*"
+            + re.escape('printf "Character database update failed.\\n"')
+            + r"\s*exit 1\s*fi\s*fi)",
         )
 
     def test_loading_character_structure_does_not_dispatch_updates(self) -> None:
         self.assertNotIn("updateCharDB", shell_function("loadCharDB"))
+
+    def test_character_update_imports_return_failure_immediately(self) -> None:
+        updates = shell_function("updateCharDB")
+        imports = re.findall(
+            r'(?m)^\s*\$\{dbcommand\} "\$\{cdb\}" < "\$\{file\}".*$',
+            updates,
+        )
+        self.assertEqual(len(imports), 2)
+        for import_line in imports:
+            self.assertEqual(import_line.strip().endswith("|| return 1"), True)
+
+    def test_character_update_failure_stops_later_dispatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            command_log = temporary_path / "dbcommand.log"
+            fake_mariadb = temporary_path / "mariadb"
+            fake_mariadb.write_text(
+                "#!/bin/sh\n"
+                "database=\n"
+                "for argument do database=${argument}; done\n"
+                "printf '%s\\n' \"${database}\" >> \"${WARDEN_DB_COMMAND_LOG}\"\n"
+                "exit 73\n",
+                encoding="utf-8",
+            )
+            fake_mariadb.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = str(temporary_path) + os.pathsep + environment["PATH"]
+            environment["WARDEN_DB_COMMAND_LOG"] = str(command_log)
+            result = subprocess.run(
+                [bash_executable(), str(ROOT / "InstallDatabases.sh"), "-su"],
+                cwd=ROOT,
+                input="host\nuser\n3306\npass\ncharacter_test\nworld_test\nrealm_test\n",
+                capture_output=True,
+                check=False,
+                text=True,
+                env=environment,
+            )
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("Character database update failed.", result.stdout)
+            self.assertNotIn("Database creation and load complete :-)", result.stdout)
+            self.assertEqual(
+                command_log.read_text(encoding="utf-8").splitlines(),
+                ["character_test"],
+            )
 
 
 class WardenBackupRoutingTests(unittest.TestCase):

--- a/Tools/tests/test_warden_transition_scripts.py
+++ b/Tools/tests/test_warden_transition_scripts.py
@@ -108,6 +108,64 @@ def bash_executable() -> str:
 
 
 class CharacterUpdateRoutingTests(unittest.TestCase):
+    def run_update_failure(
+        self, failed_database: str, populate_old_world: bool = False
+    ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            releases = re.findall(r'(?m)^(?:OLDRELEASE|RELEASE)="([^"]+)"$', INSTALL)
+            self.assertEqual(len(releases), 2)
+            for database in ("Character", "World", "Realm"):
+                for release in releases:
+                    update_directory = temporary_path / database / "Updates" / release
+                    update_directory.mkdir(parents=True, exist_ok=True)
+                    if (
+                        database == "World"
+                        and release == releases[0]
+                        and not populate_old_world
+                    ):
+                        continue
+                    (update_directory / "fixture.sql").write_text(
+                        "-- controlled update fixture\n", encoding="utf-8"
+                    )
+            world_calls = 1 + int(populate_old_world)
+            fail_call = len(releases) + world_calls
+            if failed_database == "realm_test":
+                fail_call += 1
+            command_log = temporary_path / "dbcommand.log"
+            fake_mariadb = temporary_path / "mariadb"
+            fake_mariadb.write_text(
+                "#!/bin/sh\n"
+                "database=\n"
+                "for argument do database=${argument}; done\n"
+                "count_file=${WARDEN_DB_COMMAND_LOG}.count\n"
+                "count=0\n"
+                "if [ -f \"${count_file}\" ]; then read count < \"${count_file}\"; fi\n"
+                "count=$((count + 1))\n"
+                "printf '%s\\n' \"${database}\" >> \"${WARDEN_DB_COMMAND_LOG}\"\n"
+                "printf '%s\\n' \"${count}\" > \"${count_file}\"\n"
+                f"if [ \"${{count}}\" -eq {fail_call} ]; then\n"
+                "    exit 73\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            fake_mariadb.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = str(temporary_path) + os.pathsep + environment["PATH"]
+            environment["WARDEN_DB_COMMAND_LOG"] = str(command_log)
+            result = subprocess.run(
+                [bash_executable(), str(ROOT / "InstallDatabases.sh"), "-su"],
+                cwd=temporary_path,
+                input="host\nuser\n3306\npass\ncharacter_test\nworld_test\nrealm_test\n",
+                capture_output=True,
+                check=False,
+                text=True,
+                env=environment,
+            )
+            commands = command_log.read_text(encoding="utf-8").splitlines()
+        return result, commands
+
     def test_character_updates_are_dispatched_from_the_top_level(self) -> None:
         execution = INSTALL[INSTALL.index('if [ "${createcharDB}" = "YES" ]') :]
         self.assertRegex(
@@ -164,6 +222,35 @@ class CharacterUpdateRoutingTests(unittest.TestCase):
                 command_log.read_text(encoding="utf-8").splitlines(),
                 ["character_test"],
             )
+
+    def test_world_update_failure_stops_realm_and_success_dispatch(self) -> None:
+        result, commands = self.run_update_failure(
+            "world_test", populate_old_world=True
+        )
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("World database update failed.", result.stdout)
+        self.assertNotIn("Database creation and load complete :-)", result.stdout)
+        self.assertEqual(commands.count("world_test"), 2)
+        self.assertNotIn("realm_test", commands)
+
+    def test_empty_old_world_release_reaches_current_update(self) -> None:
+        result, commands = self.run_update_failure("realm_test")
+        releases = re.findall(r'(?m)^(?:OLDRELEASE|RELEASE)="([^"]+)"$', INSTALL)
+
+        self.assertIn(
+            f"Applying update World/Updates/{releases[1]}/fixture.sql",
+            result.stdout,
+        )
+        self.assertEqual(commands.count("world_test"), 1)
+
+    def test_realm_update_failure_stops_success_dispatch(self) -> None:
+        result, commands = self.run_update_failure("realm_test")
+
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Realm database update failed.", result.stdout)
+        self.assertNotIn("Database creation and load complete :-)", result.stdout)
+        self.assertEqual(commands.count("realm_test"), 1)
 
 
 class WardenBackupRoutingTests(unittest.TestCase):

--- a/Tools/tests/test_warden_transition_scripts.py
+++ b/Tools/tests/test_warden_transition_scripts.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# MaNGOS is a full featured server for World of Warcraft, supporting
+# the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+#
+# Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# World of Warcraft, and all World of Warcraft or Warcraft art, images,
+# and lore are copyrighted by Blizzard Entertainment, Inc.
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INSTALL = (ROOT / "InstallDatabases.sh").read_text(encoding="utf-8")
+BACKUP = (ROOT / "Tools" / "backupDB.cmd").read_text(encoding="utf-8")
+
+
+def shell_function(name: str) -> str:
+    match = re.search(
+        rf"(?ms)^{re.escape(name)}\(\)\s*\{{\s*(.*?)^\}}\s*$",
+        INSTALL,
+    )
+    if not match:
+        raise AssertionError(f"missing shell function {name}")
+    return match.group(1)
+
+
+def batch_label(name: str, next_label: str) -> str:
+    match = re.search(
+        rf"(?ms)^:{re.escape(name)}\s*$\s*(.*?)^:{re.escape(next_label)}\s*$",
+        BACKUP,
+    )
+    if not match:
+        raise AssertionError(f"missing batch label {name}")
+    return match.group(1)
+
+
+class CharacterUpdateRoutingTests(unittest.TestCase):
+    def test_character_updates_are_dispatched_from_the_top_level(self) -> None:
+        execution = INSTALL[INSTALL.index('if [ "${createcharDB}" = "YES" ]') :]
+        self.assertRegex(
+            execution,
+            re.escape('if [ "${updatecharDB}" = "YES" ]; then')
+            + r"(?s:\s*updateCharDB\s*fi)",
+        )
+
+    def test_loading_character_structure_does_not_dispatch_updates(self) -> None:
+        self.assertNotIn("updateCharDB", shell_function("loadCharDB"))
+
+
+class WardenBackupRoutingTests(unittest.TestCase):
+    EXPECTED_OPTIONAL_TABLES = {
+        ("%wdb%", "_full_worlddb", "%loadworldDB%", "warden"),
+        ("%wdb%", "_full_worlddb", "%loadworldDB%", "warden_checks"),
+        ("%cdb%", "_full_chardb", "%loadcharDB%", "warden_action"),
+        ("%rdb%", "_full_realmdb", "%loadrealmDB%", "warden_log"),
+        ("%rdb%", "_full_realmdb", "%loadrealmDB%", "warden_incident"),
+        ("%rdb%", "_full_realmdb", "%loadrealmDB%", "warden_audit"),
+    }
+
+    def optional_calls(self) -> set[tuple[str, str, str, str]]:
+        return set(
+            re.findall(
+                r'(?im)^call :DumpOptionalTable "([^"]+)" "([^"]+)" '
+                r'"([^"]+)" "([^"]+)"\s*$',
+                BACKUP,
+            )
+        )
+
+    def test_legacy_and_replacement_tables_are_both_optional(self) -> None:
+        self.assertEqual(self.optional_calls(), self.EXPECTED_OPTIONAL_TABLES)
+        self.assertNotRegex(
+            BACKUP,
+            r"(?im)^SET TABLENAME=(warden|warden_checks|warden_action|"
+            r"warden_log|warden_incident|warden_audit)\s*$",
+        )
+
+    def test_optional_table_probe_distinguishes_absence_from_failure(self) -> None:
+        helper = batch_label("DumpOptionalTable", "patherror")
+        self.assertIn("information_schema.tables", helper)
+        self.assertIn('if not "%OPTIONALFOUND%" == "0" if not ', helper)
+        self.assertIn("exit /b 1", helper)
+        self.assertEqual(
+            len(re.findall(r"(?im)^if errorlevel 1 goto error\s*$", BACKUP)),
+            len(self.EXPECTED_OPTIONAL_TABLES),
+        )
+
+    def test_absence_removes_only_the_exact_stale_output_after_probe(self) -> None:
+        helper = batch_label("DumpOptionalTable", "patherror")
+        validated = helper.index(
+            'if not "%OPTIONALFOUND%" == "0" if not '
+        )
+        absent = helper.index('if "%OPTIONALFOUND%" == "0" (')
+        deletion = helper.index(
+            'if exist "%OPTIONALOUTPUT%" del /Q "%OPTIONALOUTPUT%"'
+        )
+        self.assertLess(validated, absent)
+        self.assertLess(absent, deletion)
+        self.assertEqual(
+            helper.count(
+                'if exist "%OPTIONALOUTPUT%" del /Q "%OPTIONALOUTPUT%"'
+            ),
+            1,
+        )
+        self.assertNotRegex(helper, r'del /Q "[^"\r\n]*\*[^"\r\n]*"')
+
+    def test_present_table_output_is_published_only_after_complete_dump(self) -> None:
+        helper = batch_label("DumpOptionalTable", "patherror")
+        dump = helper.index('> "%OPTIONALTEMP%"')
+        ready = helper.index('move /Y "%OPTIONALTEMP%" "%OPTIONALREADY%"')
+        publish = helper.index(
+            'move /Y "%OPTIONALREADY%" "%OPTIONALOUTPUT%" >nul'
+        )
+        self.assertLess(dump, ready)
+        self.assertLess(ready, publish)
+        self.assertNotIn('>> "%OPTIONALOUTPUT%"', helper)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/World/Updates/Rel22/Rel22_06_003_Warden_Checks.sql
+++ b/World/Updates/Rel22/Rel22_06_003_Warden_Checks.sql
@@ -1,0 +1,173 @@
+-- ----------------------------------------------------------------
+-- Replace the legacy opaque Warden table with exact typed profiles.
+-- IMPORTANT: export any custom `warden` rows before applying this
+-- intentionally destructive update. No automatic conversion is safe.
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        SHOW ERRORS;
+        SELECT '* UPDATE FAILED *' AS `===== Status =====`,
+               @cCurResult AS `===== DB is on Version: =====`;
+        RESIGNAL;
+    END;
+
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '06';
+    SET @cOldContent = '002';
+
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '06';
+    SET @cNewContent = '003';
+    SET @cNewDescription = 'Warden_Checks';
+    SET @cNewComment = 'Replace legacy Warden rows with exact typed checks';
+
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cOldResult := (SELECT `description` FROM `db_version` WHERE `version` = @cOldVersion AND `structure` = @cOldStructure AND `content` = @cOldContent);
+    SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version` = @cNewVersion AND `structure` = @cNewStructure AND `content` = @cNewContent);
+
+    IF (@cCurResult = @cOldResult) THEN
+        START TRANSACTION;
+
+        -- At 22/06/002 this name is unowned. Removing it makes a failed
+        -- non-transactional DDL attempt safely re-runnable.
+        DROP TABLE IF EXISTS `warden_checks`;
+        CREATE TABLE `warden_checks` (
+          `build` SMALLINT UNSIGNED NOT NULL,
+          `platform` VARBINARY(4) NOT NULL,
+          `locale` BINARY(4) NOT NULL,
+          `check_id` INT UNSIGNED NOT NULL,
+          `type` TINYINT UNSIGNED NOT NULL,
+          `enabled` TINYINT UNSIGNED NOT NULL,
+          `sort_order` SMALLINT UNSIGNED NOT NULL,
+          `evidence_class` TINYINT UNSIGNED NOT NULL,
+          `module` VARBINARY(255) NOT NULL DEFAULT '',
+          `address` INT UNSIGNED NOT NULL DEFAULT 0,
+          `length` SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+          `request` VARBINARY(255) NOT NULL DEFAULT '',
+          `expected` VARBINARY(255) NOT NULL DEFAULT '',
+          `comment` VARCHAR(255) NOT NULL DEFAULT '',
+          PRIMARY KEY (`build`,`platform`,`locale`,`check_id`),
+          UNIQUE KEY `uq_warden_checks_profile_order`
+            (`build`,`platform`,`locale`,`sort_order`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC
+          COMMENT='Exact typed Warden check catalogue';
+
+        INSERT INTO `warden_checks`
+        (`build`,`platform`,`locale`,`check_id`,`type`,`enabled`,`sort_order`,
+         `evidence_class`,`module`,`address`,`length`,`request`,`expected`,`comment`)
+        VALUES
+        (5875,0x57696E,0x656E5553,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (5875,0x57696E,0x656E5553,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x7D88154D3411811985F5D81177C5453248133443,
+         'Effective AreaTable baseline; corroboration only'),
+        (5875,0x57696E,0x656E5553,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x4F6B6179,'Localized OKAY callback; addons may mutate globals'),
+        (5875,0x57696E,0x656E5553,1107,243,1,40,1,X'',6392064,32,X'',
+         0x558BEC8B51408B450C81E2FF7DA075508950108B450850E824DA1A005DC20800,
+         'Re-authored complete client function invariant'),
+        (5875,0x57696E,0x656E5553,827,243,1,50,1,X'',8151558,13,X'',
+         0x25FFFFDFFB0D00200000894640,
+         'Re-authored complete air-swim invariant'),
+        (5875,0x57696E,0x656E5553,1566,243,1,60,2,X'',4803152,5,X'',
+         0xA1C0EACE00,'Source-backed RemoveLuaProtection entry mutation'),
+        (5875,0x57696E,0x656E5553,1135,243,1,70,3,X'',8445948,4,X'',
+         0xBB8D243F,'Wall-climb constant without active malicious fixture'),
+
+        (6005,0x57696E,0x656E4742,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (6005,0x57696E,0x656E4742,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x7D88154D3411811985F5D81177C5453248133443,
+         'Effective AreaTable baseline; corroboration only'),
+        (6005,0x57696E,0x656E4742,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x4F6B6179,'Localized OKAY callback; addons may mutate globals'),
+        (6005,0x57696E,0x656E4742,1107,243,1,40,1,X'',6392064,32,X'',
+         0x558BEC8B51408B450C81E2FF7DA075508950108B450850E864DA1A005DC20800,
+         'Re-authored complete client function invariant'),
+        (6005,0x57696E,0x656E4742,827,243,1,50,1,X'',8151622,13,X'',
+         0x25FFFFDFFB0D00200000894640,
+         'Re-authored complete air-swim invariant'),
+        (6005,0x57696E,0x656E4742,1566,243,1,60,2,X'',4803152,5,X'',
+         0xA1C0EACE00,'Source-backed RemoveLuaProtection entry mutation'),
+        (6005,0x57696E,0x656E4742,1135,243,1,70,3,X'',8445948,4,X'',
+         0xBB8D243F,'Wall-climb constant without active malicious fixture'),
+
+        (6141,0x57696E,0x7A68434E,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (6141,0x57696E,0x7A68434E,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0xC5A1DE4C1CD412EB4D2E02AFAB6131B737EFCAF0,
+         'Effective AreaTable baseline; corroboration only'),
+        (6141,0x57696E,0x7A68434E,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0xE7A1AEE5AE9A,'Localized OKAY callback; addons may mutate globals'),
+        (6141,0x57696E,0x7A68434E,1107,243,1,40,1,X'',6401184,32,X'',
+         0x558BEC8B51408B450C81E2FF7DA075508950108B450850E864EB1A005DC20800,
+         'Re-authored complete client function invariant'),
+        (6141,0x57696E,0x7A68434E,827,243,1,50,1,X'',8165094,13,X'',
+         0x25FFFFDFFB0D00200000894640,
+         'Re-authored complete air-swim invariant'),
+        (6141,0x57696E,0x7A68434E,1566,243,1,60,2,X'',4806720,5,X'',
+         0xA1E031CF00,'Source-backed RemoveLuaProtection entry mutation'),
+        (6141,0x57696E,0x7A68434E,1135,243,1,70,3,X'',8462780,4,X'',
+         0xBB8D243F,'Wall-climb constant without active malicious fixture');
+
+        IF (SELECT COUNT(*) FROM `warden_checks`) <> 21
+           OR (SELECT COUNT(DISTINCT `build`,`platform`,`locale`)
+               FROM `warden_checks`) <> 3
+           OR (SELECT COUNT(*) FROM `warden_checks` WHERE `enabled` = 1) <> 21 THEN
+            SIGNAL SQLSTATE '45000'
+              SET MESSAGE_TEXT = 'Warden check seed validation failed';
+        END IF;
+
+        -- The recoverable legacy table is removed only after the complete new
+        -- seed has validated successfully.
+        DROP TABLE IF EXISTS `warden`;
+
+        INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure,
+            @cNewContent, @cNewDescription, @cNewComment);
+        SET @cNewResult := (SELECT `description` FROM `db_version`
+            WHERE `version` = @cNewVersion AND `structure` = @cNewStructure
+              AND `content` = @cNewContent);
+        COMMIT;
+        SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,
+               @cNewResult AS `===== DB is now on Version =====`;
+    ELSE
+        IF (@cCurResult = @cNewResult) THEN
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,
+                   @cCurResult AS `===== DB is already on Version =====`;
+        ELSE
+            IF (@cCurResult IS NULL) THEN
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,
+                       'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure,
+                    '_', @cCurContent, ' - ', @cCurResult);
+                SET @cOldOutput = CONCAT(@cOldVersion, '_', @cOldStructure,
+                    '_', @cOldContent, ' - ',
+                    COALESCE(@cOldResult, 'IS NOT APPLIED'));
+                SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,
+                       @cOldOutput AS `=== Expected ===`,
+                       @cCurOutput AS `===== Found Version =====`;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+CALL update_mangos();
+
+DROP PROCEDURE IF EXISTS `update_mangos`;


### PR DESCRIPTION
## Summary

- replace the legacy World `warden` table with typed, profile-scoped `warden_checks`
- seed 21 validated checks across 5875/enUS, 6005/enGB, and 6141/zhCN
- remove the obsolete Character `warden_action` table
- advance the Realm submodule to the exact-locale, audit, and generalized-incident schema
- use fail-stop Rel22 migration wrappers and validated destructive-table custody

## Why

The redesigned Warden runtime loads its complete check catalogue from the World database and no longer uses the untyped legacy rows or per-check punishment table. Realm persistence now separates audit-only findings from actionable incidents.

## Dependency

Includes the Realm schema from [mangos/Realm_DB#10](https://github.com/mangos/Realm_DB/pull/10).

## Operator impact

Apply World through `22/06/003`, Character through `22/05/004`, and Realm through `22/04/001` before starting the corresponding server branch. The migrations intentionally drop the old `warden`, `warden_action`, and `warden_log` tables after their replacement structures are established.

## Validation

- exact 21-row seed verifier passed across three profiles
- World/Character fail-stop wrappers and frozen setup baselines passed
- fresh and populated upgrade schemas/data converged exactly
- partial Realm DDL recovery passed
- legacy tables were confirmed absent in the final migrated state

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/database/158)
<!-- Reviewable:end -->
