### PR TITLE
Add Classic Warden locale hardening profiles

### DIFF
--- a/Tools/tests/test_warden_locale_hardening_update.py
+++ b/Tools/tests/test_warden_locale_hardening_update.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# MaNGOS is a full featured server for World of Warcraft, supporting
+# the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+#
+# Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# World of Warcraft, and all World of Warcraft or Warcraft art, images,
+# and lore are copyrighted by Blizzard Entertainment, Inc.
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+UPDATE_PATH = (
+    ROOT / "World" / "Updates" / "Rel22"
+    / "Rel22_06_004_Warden_Locale_Hardening.sql"
+)
+
+
+class WardenLocaleHardeningUpdateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not UPDATE_PATH.is_file():
+            raise AssertionError(f"missing {UPDATE_PATH.name}")
+        cls.sql = UPDATE_PATH.read_text(encoding="utf-8")
+
+    def row(self, build: int, locale_hex: str, check_id: int) -> str:
+        match = re.search(
+            rf"(?ms)^\s*\({build},0x57696E,0x{locale_hex},{check_id},.*?"
+            r"\)(?:,|;)$",
+            self.sql,
+        )
+        self.assertIsNotNone(
+            match, f"missing {build}/Win/{locale_hex} check {check_id}"
+        )
+        return match.group(0)
+
+    def test_advances_only_the_expected_world_database_revision(self) -> None:
+        self.assertIn("SET @cOldVersion = '22';", self.sql)
+        self.assertIn("SET @cOldStructure = '06';", self.sql)
+        self.assertIn("SET @cOldContent = '003';", self.sql)
+        self.assertIn("SET @cNewVersion = '22';", self.sql)
+        self.assertIn("SET @cNewStructure = '06';", self.sql)
+        self.assertIn("SET @cNewContent = '004';", self.sql)
+        self.assertIn("SET @cNewDescription = 'Warden_Locale_Hardening';", self.sql)
+        self.assertNotRegex(self.sql, r"(?i)INSERT\s+(?:IGNORE\s+)?INTO\s+`?db_version`?.*003")
+
+    def test_adds_five_complete_profiles_and_hardens_three_existing_ones(self) -> None:
+        expected_ids = {65536, 1, 2, 1107, 827, 1566, 1135, 65537, 65538}
+        new_profiles = {
+            (5875, "6B6F4B52"),
+            (5875, "7A685457"),
+            (5875, "66724652"),
+            (5875, "65734553"),
+            (6005, "64654445"),
+        }
+        existing_profiles = {
+            (5875, "656E5553"),
+            (6005, "656E4742"),
+            (6141, "7A68434E"),
+        }
+
+        rows = re.findall(
+            r"(?m)^\s*\((\d+),0x57696E,0x([0-9A-F]{8}),(\d+),",
+            self.sql,
+        )
+        self.assertEqual(len(rows), 51)
+        actual: dict[tuple[int, str], set[int]] = {}
+        for build, locale, check_id in rows:
+            actual.setdefault((int(build), locale), set()).add(int(check_id))
+        for profile in new_profiles:
+            self.assertEqual(actual.get(profile), expected_ids)
+        for profile in existing_profiles:
+            self.assertEqual(actual.get(profile), {65537, 65538})
+        self.assertEqual(set(actual), new_profiles | existing_profiles)
+
+    def test_pins_each_new_localized_archive_and_lua_expectation(self) -> None:
+        expectations = {
+            (5875, "6B6F4B52"): (
+                "755D6D7F49BB34114433386D559261ED3AA23F00", "ED9995EC9DB8"
+            ),
+            (5875, "7A685457"): (
+                "2A70E6402A40A4F9E9960CED419DBA5E6DEB8536", "E7A2BAE5AE9A"
+            ),
+            (5875, "66724652"): (
+                "AF2D81AF013A9BA6BB92CE171E43FA903C9E8C09", "4F4B"
+            ),
+            (5875, "65734553"): (
+                "1ECEC2C6596B8411FA5FE153EDFB9A6EE43360E9", "41636570746172"
+            ),
+            (6005, "64654445"): (
+                "A0B3DC2D78AD892F2436BCD937BE51B4989D64C1", "4F4B"
+            ),
+        }
+        for (build, locale), (mpq_sha1, lua_text) in expectations.items():
+            self.assertIn(f"0x{mpq_sha1}", self.row(build, locale, 1))
+            self.assertIn(f"0x{lua_text}", self.row(build, locale, 2))
+
+    def test_pins_signature_dispatch_tables_for_every_profile(self) -> None:
+        profiles = {
+            (5875, "656E5553"), (5875, "6B6F4B52"),
+            (5875, "7A685457"), (5875, "66724652"),
+            (5875, "65734553"), (6005, "656E4742"),
+            (6005, "64654445"), (6141, "7A68434E"),
+        }
+        for build, locale in profiles:
+            glue = self.row(build, locale, 65537)
+            self.assertRegex(
+                glue,
+                r",243,1,80,1,X'',4631212,16,X'',"
+                r"\s*0x1CA9460029A9460036A946009EA94600,",
+            )
+            frame = self.row(build, locale, 65538)
+            if build == 6141:
+                address = 4788152
+                expected = "4E0D49005B0D4900680D4900850D4900"
+            else:
+                address = 4784584
+                expected = "5EFF48006BFF480078FF480095FF4800"
+            self.assertRegex(
+                frame,
+                rf",243,1,90,1,X'',{address},16,X'',\s*0x{expected},",
+            )
+
+    def test_validates_required_rows_without_rejecting_operator_tuning(self) -> None:
+        self.assertRegex(
+            self.sql,
+            r"(?s)SET @cRequiredSeedRows :=\s*\(.*?"
+            r"\(`build`,`platform`,`locale`\) IN\s*\(\s*"
+            r"\(5875,0x57696E,0x656E5553\),\s*"
+            r"\(6005,0x57696E,0x656E4742\),\s*"
+            r"\(6141,0x57696E,0x7A68434E\)\s*\).*?"
+            r"`check_id` IN\s*\(1,2,827,1107,1135,1566,65536\).*?"
+            r"IF @cRequiredSeedRows <> 21",
+        )
+        self.assertRegex(
+            self.sql,
+            r"(?s)SET @cRequiredExpandedRows :=\s*\(.*?"
+            r"\(5875,0x57696E,0x656E5553\),\s*"
+            r"\(5875,0x57696E,0x6B6F4B52\),\s*"
+            r"\(5875,0x57696E,0x7A685457\),\s*"
+            r"\(5875,0x57696E,0x66724652\),\s*"
+            r"\(5875,0x57696E,0x65734553\),\s*"
+            r"\(6005,0x57696E,0x656E4742\),\s*"
+            r"\(6005,0x57696E,0x64654445\),\s*"
+            r"\(6141,0x57696E,0x7A68434E\)\s*\).*?"
+            r"`check_id` IN\s*\(1,2,827,1107,1135,1566,65536,65537,65538\).*?"
+            r"IF @cRequiredExpandedRows <> 72",
+        )
+        self.assertNotRegex(
+            self.sql,
+            r"COUNT\(\*\) FROM `warden_checks` WHERE `enabled` = 1",
+        )
+        self.assertIn("restore the canonical 22/06/003 seed", self.sql)
+        self.assertIn("START TRANSACTION;", self.sql)
+        self.assertIn("ROLLBACK;", self.sql)
+        self.assertIn("COMMIT;", self.sql)
+        self.assertNotRegex(self.sql, r"(?i)INSERT\s+IGNORE|REPLACE\s+INTO")
+
+    def test_preserves_operator_rows_while_reserving_new_id_and_order_slots(self) -> None:
+        self.assertIn(
+            "Custom Warden check IDs 65537/65538 conflict", self.sql
+        )
+        self.assertIn(
+            "Custom rows already use a new Warden locale profile", self.sql
+        )
+        self.assertIn(
+            "Warden sort_order relocation would overflow", self.sql
+        )
+        self.assertRegex(
+            self.sql,
+            r"(?s)UPDATE `warden_checks`\s+"
+            r"SET `sort_order` = `sort_order` \+ 20\s+"
+            r"WHERE \(`build`,`platform`,`locale`\) IN\s*\(\s*"
+            r"\(5875,0x57696E,0x656E5553\),\s*"
+            r"\(6005,0x57696E,0x656E4742\),\s*"
+            r"\(6141,0x57696E,0x7A68434E\)\s*\)\s+"
+            r"AND `sort_order` >= 80\s+"
+            r"ORDER BY `sort_order` DESC;",
+        )
+        self.assertLess(
+            self.sql.index("SET `sort_order` = `sort_order` + 20"),
+            self.sql.index("INSERT INTO `warden_checks`"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/World/Updates/Rel22/Rel22_06_004_Warden_Locale_Hardening.sql
+++ b/World/Updates/Rel22/Rel22_06_004_Warden_Locale_Hardening.sql
@@ -1,0 +1,311 @@
+-- ----------------------------------------------------------------
+-- Add verified Classic Windows locale profiles and protect the two
+-- interface-signature dispatch tables used by the client.
+-- ----------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`;
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        SHOW ERRORS;
+        SELECT '* UPDATE FAILED *' AS `===== Status =====`,
+               @cCurResult AS `===== DB is on Version: =====`;
+        RESIGNAL;
+    END;
+
+    SET @cCurVersion := (SELECT `version` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cCurStructure := (SELECT `structure` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cCurContent := (SELECT `content` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+
+    SET @cOldVersion = '22';
+    SET @cOldStructure = '06';
+    SET @cOldContent = '003';
+
+    SET @cNewVersion = '22';
+    SET @cNewStructure = '06';
+    SET @cNewContent = '004';
+    SET @cNewDescription = 'Warden_Locale_Hardening';
+    SET @cNewComment = 'Add verified locale profiles and interface signature checks';
+
+    SET @cCurResult := (SELECT `description` FROM `db_version` ORDER BY `version` DESC, `structure` DESC, `content` DESC LIMIT 0,1);
+    SET @cOldResult := (SELECT `description` FROM `db_version` WHERE `version` = @cOldVersion AND `structure` = @cOldStructure AND `content` = @cOldContent);
+    SET @cNewResult := (SELECT `description` FROM `db_version` WHERE `version` = @cNewVersion AND `structure` = @cNewStructure AND `content` = @cNewContent);
+
+    IF (@cCurResult = @cOldResult) THEN
+        START TRANSACTION;
+
+        -- Require every canonical 22/06/003 identity while preserving
+        -- operator-added rows and enabled-state choices.
+        SET @cRequiredSeedRows :=
+          (SELECT COUNT(*) FROM `warden_checks`
+           WHERE (`build`,`platform`,`locale`) IN
+             ((5875,0x57696E,0x656E5553),
+              (6005,0x57696E,0x656E4742),
+              (6141,0x57696E,0x7A68434E))
+             AND `check_id` IN (1,2,827,1107,1135,1566,65536));
+        IF @cRequiredSeedRows <> 21 THEN
+            SIGNAL SQLSTATE '45000'
+              SET MESSAGE_TEXT = 'Required Warden rows are missing; restore the canonical 22/06/003 seed';
+        END IF;
+
+        -- The new IDs carry stable audit identity and cannot be reassigned.
+        IF EXISTS
+          (SELECT 1 FROM `warden_checks`
+           WHERE (`build`,`platform`,`locale`) IN
+             ((5875,0x57696E,0x656E5553),
+              (6005,0x57696E,0x656E4742),
+              (6141,0x57696E,0x7A68434E))
+             AND `check_id` IN (65537,65538)) THEN
+            SIGNAL SQLSTATE '45000'
+              SET MESSAGE_TEXT = 'Custom Warden check IDs 65537/65538 conflict; renumber them before retrying';
+        END IF;
+
+        -- A locally authored version of a new exact profile needs an explicit
+        -- operator merge; silently combining two baselines would be unsafe.
+        IF EXISTS
+          (SELECT 1 FROM `warden_checks`
+           WHERE (`build`,`platform`,`locale`) IN
+             ((5875,0x57696E,0x6B6F4B52),
+              (5875,0x57696E,0x7A685457),
+              (5875,0x57696E,0x66724652),
+              (5875,0x57696E,0x65734553),
+              (6005,0x57696E,0x64654445))) THEN
+            SIGNAL SQLSTATE '45000'
+              SET MESSAGE_TEXT = 'Custom rows already use a new Warden locale profile; merge or remove them before retrying';
+        END IF;
+
+        -- Preserve custom check order while reserving 80 and 90 for the two
+        -- appended canonical checks. Descending order avoids transient unique
+        -- key collisions as every existing slot from 80 upward moves by 20.
+        IF EXISTS
+          (SELECT 1 FROM `warden_checks`
+           WHERE (`build`,`platform`,`locale`) IN
+             ((5875,0x57696E,0x656E5553),
+              (6005,0x57696E,0x656E4742),
+              (6141,0x57696E,0x7A68434E))
+             AND `sort_order` > 65515) THEN
+            SIGNAL SQLSTATE '45000'
+              SET MESSAGE_TEXT = 'Warden sort_order relocation would overflow; renumber values above 65515 before retrying';
+        END IF;
+
+        UPDATE `warden_checks`
+        SET `sort_order` = `sort_order` + 20
+        WHERE (`build`,`platform`,`locale`) IN
+          ((5875,0x57696E,0x656E5553),
+           (6005,0x57696E,0x656E4742),
+           (6141,0x57696E,0x7A68434E))
+          AND `sort_order` >= 80
+        ORDER BY `sort_order` DESC;
+
+        INSERT INTO `warden_checks`
+        (`build`,`platform`,`locale`,`check_id`,`type`,`enabled`,`sort_order`,
+         `evidence_class`,`module`,`address`,`length`,`request`,`expected`,`comment`)
+        VALUES
+        -- Harden the three profiles introduced by 22/06/003.
+        (5875,0x57696E,0x656E5553,65537,243,1,80,1,X'',4631212,16,X'',
+         0x1CA9460029A9460036A946009EA94600,
+         'GlueXML interface-signature dispatch invariant'),
+        (5875,0x57696E,0x656E5553,65538,243,1,90,1,X'',4784584,16,X'',
+         0x5EFF48006BFF480078FF480095FF4800,
+         'FrameXML interface-signature dispatch invariant'),
+        (6005,0x57696E,0x656E4742,65537,243,1,80,1,X'',4631212,16,X'',
+         0x1CA9460029A9460036A946009EA94600,
+         'GlueXML interface-signature dispatch invariant'),
+        (6005,0x57696E,0x656E4742,65538,243,1,90,1,X'',4784584,16,X'',
+         0x5EFF48006BFF480078FF480095FF4800,
+         'FrameXML interface-signature dispatch invariant'),
+        (6141,0x57696E,0x7A68434E,65537,243,1,80,1,X'',4631212,16,X'',
+         0x1CA9460029A9460036A946009EA94600,
+         'GlueXML interface-signature dispatch invariant'),
+        (6141,0x57696E,0x7A68434E,65538,243,1,90,1,X'',4788152,16,X'',
+         0x4E0D49005B0D4900680D4900850D4900,
+         'FrameXML interface-signature dispatch invariant'),
+
+        -- 1.12.1 build 5875 Korean.
+        (5875,0x57696E,0x6B6F4B52,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (5875,0x57696E,0x6B6F4B52,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x755D6D7F49BB34114433386D559261ED3AA23F00,
+         'Effective AreaTable baseline; corroboration only'),
+        (5875,0x57696E,0x6B6F4B52,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0xED9995EC9DB8,'Localized OKAY callback; addons may mutate globals'),
+        (5875,0x57696E,0x6B6F4B52,1107,243,1,40,1,X'',6392064,32,X'',
+         0x558BEC8B51408B450C81E2FF7DA075508950108B450850E824DA1A005DC20800,
+         'Re-authored complete client function invariant'),
+        (5875,0x57696E,0x6B6F4B52,827,243,1,50,1,X'',8151558,13,X'',
+         0x25FFFFDFFB0D00200000894640,
+         'Re-authored complete air-swim invariant'),
+        (5875,0x57696E,0x6B6F4B52,1566,243,1,60,2,X'',4803152,5,X'',
+         0xA1C0EACE00,'Source-backed RemoveLuaProtection entry mutation'),
+        (5875,0x57696E,0x6B6F4B52,1135,243,1,70,3,X'',8445948,4,X'',
+         0xBB8D243F,'Wall-climb constant without active malicious fixture'),
+        (5875,0x57696E,0x6B6F4B52,65537,243,1,80,1,X'',4631212,16,X'',
+         0x1CA9460029A9460036A946009EA94600,
+         'GlueXML interface-signature dispatch invariant'),
+        (5875,0x57696E,0x6B6F4B52,65538,243,1,90,1,X'',4784584,16,X'',
+         0x5EFF48006BFF480078FF480095FF4800,
+         'FrameXML interface-signature dispatch invariant'),
+
+        -- 1.12.1 build 5875 Traditional Chinese. The expectations describe
+        -- a clean executable; modified distributions must not be whitelisted.
+        (5875,0x57696E,0x7A685457,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (5875,0x57696E,0x7A685457,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x2A70E6402A40A4F9E9960CED419DBA5E6DEB8536,
+         'Effective AreaTable baseline; corroboration only'),
+        (5875,0x57696E,0x7A685457,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0xE7A2BAE5AE9A,'Localized OKAY callback; addons may mutate globals'),
+        (5875,0x57696E,0x7A685457,1107,243,1,40,1,X'',6392064,32,X'',
+         0x558BEC8B51408B450C81E2FF7DA075508950108B450850E824DA1A005DC20800,
+         'Re-authored complete client function invariant'),
+        (5875,0x57696E,0x7A685457,827,243,1,50,1,X'',8151558,13,X'',
+         0x25FFFFDFFB0D00200000894640,
+         'Re-authored complete air-swim invariant'),
+        (5875,0x57696E,0x7A685457,1566,243,1,60,2,X'',4803152,5,X'',
+         0xA1C0EACE00,'Source-backed RemoveLuaProtection entry mutation'),
+        (5875,0x57696E,0x7A685457,1135,243,1,70,3,X'',8445948,4,X'',
+         0xBB8D243F,'Wall-climb constant without active malicious fixture'),
+        (5875,0x57696E,0x7A685457,65537,243,1,80,1,X'',4631212,16,X'',
+         0x1CA9460029A9460036A946009EA94600,
+         'GlueXML interface-signature dispatch invariant'),
+        (5875,0x57696E,0x7A685457,65538,243,1,90,1,X'',4784584,16,X'',
+         0x5EFF48006BFF480078FF480095FF4800,
+         'FrameXML interface-signature dispatch invariant'),
+
+        -- 1.12.1 build 5875 French.
+        (5875,0x57696E,0x66724652,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (5875,0x57696E,0x66724652,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0xAF2D81AF013A9BA6BB92CE171E43FA903C9E8C09,
+         'Effective AreaTable baseline; corroboration only'),
+        (5875,0x57696E,0x66724652,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x4F4B,'Localized OKAY callback; addons may mutate globals'),
+        (5875,0x57696E,0x66724652,1107,243,1,40,1,X'',6392064,32,X'',
+         0x558BEC8B51408B450C81E2FF7DA075508950108B450850E824DA1A005DC20800,
+         'Re-authored complete client function invariant'),
+        (5875,0x57696E,0x66724652,827,243,1,50,1,X'',8151558,13,X'',
+         0x25FFFFDFFB0D00200000894640,
+         'Re-authored complete air-swim invariant'),
+        (5875,0x57696E,0x66724652,1566,243,1,60,2,X'',4803152,5,X'',
+         0xA1C0EACE00,'Source-backed RemoveLuaProtection entry mutation'),
+        (5875,0x57696E,0x66724652,1135,243,1,70,3,X'',8445948,4,X'',
+         0xBB8D243F,'Wall-climb constant without active malicious fixture'),
+        (5875,0x57696E,0x66724652,65537,243,1,80,1,X'',4631212,16,X'',
+         0x1CA9460029A9460036A946009EA94600,
+         'GlueXML interface-signature dispatch invariant'),
+        (5875,0x57696E,0x66724652,65538,243,1,90,1,X'',4784584,16,X'',
+         0x5EFF48006BFF480078FF480095FF4800,
+         'FrameXML interface-signature dispatch invariant'),
+
+        -- 1.12.1 build 5875 Spanish.
+        (5875,0x57696E,0x65734553,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (5875,0x57696E,0x65734553,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0x1ECEC2C6596B8411FA5FE153EDFB9A6EE43360E9,
+         'Effective AreaTable baseline; corroboration only'),
+        (5875,0x57696E,0x65734553,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x41636570746172,'Localized OKAY callback; addons may mutate globals'),
+        (5875,0x57696E,0x65734553,1107,243,1,40,1,X'',6392064,32,X'',
+         0x558BEC8B51408B450C81E2FF7DA075508950108B450850E824DA1A005DC20800,
+         'Re-authored complete client function invariant'),
+        (5875,0x57696E,0x65734553,827,243,1,50,1,X'',8151558,13,X'',
+         0x25FFFFDFFB0D00200000894640,
+         'Re-authored complete air-swim invariant'),
+        (5875,0x57696E,0x65734553,1566,243,1,60,2,X'',4803152,5,X'',
+         0xA1C0EACE00,'Source-backed RemoveLuaProtection entry mutation'),
+        (5875,0x57696E,0x65734553,1135,243,1,70,3,X'',8445948,4,X'',
+         0xBB8D243F,'Wall-climb constant without active malicious fixture'),
+        (5875,0x57696E,0x65734553,65537,243,1,80,1,X'',4631212,16,X'',
+         0x1CA9460029A9460036A946009EA94600,
+         'GlueXML interface-signature dispatch invariant'),
+        (5875,0x57696E,0x65734553,65538,243,1,90,1,X'',4784584,16,X'',
+         0x5EFF48006BFF480078FF480095FF4800,
+         'FrameXML interface-signature dispatch invariant'),
+
+        -- 1.12.2 build 6005 German.
+        (6005,0x57696E,0x64654445,65536,87,1,10,0,X'',0,0,X'',X'',
+         'Delivered-module timing health'),
+        (6005,0x57696E,0x64654445,1,152,1,20,3,X'',0,0,
+         0x444246696C6573436C69656E745C417265615461626C652E646263,
+         0xA0B3DC2D78AD892F2436BCD937BE51B4989D64C1,
+         'Effective AreaTable baseline; corroboration only'),
+        (6005,0x57696E,0x64654445,2,139,1,30,3,X'',0,0,0x4F4B4159,
+         0x4F4B,'Localized OKAY callback; addons may mutate globals'),
+        (6005,0x57696E,0x64654445,1107,243,1,40,1,X'',6392064,32,X'',
+         0x558BEC8B51408B450C81E2FF7DA075508950108B450850E864DA1A005DC20800,
+         'Re-authored complete client function invariant'),
+        (6005,0x57696E,0x64654445,827,243,1,50,1,X'',8151622,13,X'',
+         0x25FFFFDFFB0D00200000894640,
+         'Re-authored complete air-swim invariant'),
+        (6005,0x57696E,0x64654445,1566,243,1,60,2,X'',4803152,5,X'',
+         0xA1C0EACE00,'Source-backed RemoveLuaProtection entry mutation'),
+        (6005,0x57696E,0x64654445,1135,243,1,70,3,X'',8445948,4,X'',
+         0xBB8D243F,'Wall-climb constant without active malicious fixture'),
+        (6005,0x57696E,0x64654445,65537,243,1,80,1,X'',4631212,16,X'',
+         0x1CA9460029A9460036A946009EA94600,
+         'GlueXML interface-signature dispatch invariant'),
+        (6005,0x57696E,0x64654445,65538,243,1,90,1,X'',4784584,16,X'',
+         0x5EFF48006BFF480078FF480095FF4800,
+         'FrameXML interface-signature dispatch invariant');
+
+        SET @cRequiredExpandedRows :=
+          (SELECT COUNT(*) FROM `warden_checks`
+           WHERE (`build`,`platform`,`locale`) IN
+             ((5875,0x57696E,0x656E5553),
+              (5875,0x57696E,0x6B6F4B52),
+              (5875,0x57696E,0x7A685457),
+              (5875,0x57696E,0x66724652),
+              (5875,0x57696E,0x65734553),
+              (6005,0x57696E,0x656E4742),
+              (6005,0x57696E,0x64654445),
+              (6141,0x57696E,0x7A68434E))
+             AND `check_id` IN
+               (1,2,827,1107,1135,1566,65536,65537,65538));
+        IF @cRequiredExpandedRows <> 72 THEN
+            SIGNAL SQLSTATE '45000'
+              SET MESSAGE_TEXT = 'Expanded Warden canonical row validation failed';
+        END IF;
+
+        INSERT INTO `db_version` VALUES (@cNewVersion, @cNewStructure,
+            @cNewContent, @cNewDescription, @cNewComment);
+        SET @cNewResult := (SELECT `description` FROM `db_version`
+            WHERE `version` = @cNewVersion AND `structure` = @cNewStructure
+              AND `content` = @cNewContent);
+        COMMIT;
+        SELECT '* UPDATE COMPLETE *' AS `===== Status =====`,
+               @cNewResult AS `===== DB is now on Version =====`;
+    ELSE
+        IF (@cCurResult = @cNewResult) THEN
+            SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,
+                   @cCurResult AS `===== DB is already on Version =====`;
+        ELSE
+            IF (@cCurResult IS NULL) THEN
+                SELECT '* UPDATE FAILED *' AS `===== Status =====`,
+                       'Unable to locate DB Version Information' AS `============= Error Message =============`;
+            ELSE
+                SET @cCurOutput = CONCAT(@cCurVersion, '_', @cCurStructure,
+                    '_', @cCurContent, ' - ', @cCurResult);
+                SET @cOldOutput = CONCAT(@cOldVersion, '_', @cOldStructure,
+                    '_', @cOldContent, ' - ',
+                    COALESCE(@cOldResult, 'IS NOT APPLIED'));
+                SELECT '* UPDATE SKIPPED *' AS `===== Status =====`,
+                       @cOldOutput AS `=== Expected ===`,
+                       @cCurOutput AS `===== Found Version =====`;
+            END IF;
+        END IF;
+    END IF;
+END $$
+
+DELIMITER ;
+
+CALL update_mangos();
+
+DROP PROCEDURE IF EXISTS `update_mangos`;


### PR DESCRIPTION
## Summary

- add exact Classic Windows Warden profiles for koKR, zhTW, frFR, esES, and deDE
- add GlueXML and FrameXML signature-dispatch integrity checks to all eight supported profiles
- advance World DB 22/06/003 to 22/06/004 with transactional guards that preserve operator-added rows and disabled states
- keep base files untouched; this is an update-file-only database change

## Validation

- Warden database tests: 27/27 passed
- MariaDB 10.11 migration matrix: clean upgrade, custom-row preservation, missing-seed, reserved-ID, profile-conflict, and overflow scenarios passed
- live upgraded catalogue: 72 enabled rows, eight profiles, nine checks per profile
- Observe-mode client validation passed on builds 5875, 6005, and 6141; the intentional six-byte-modified zhTW client was confirmed by checks 65537 and 65538 without enforcement

Companion server PR will require World DB 22/06/004 and carries the matching catalogue, packet, planner, and version tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/database/159)
<!-- Reviewable:end -->
